### PR TITLE
Fix formatting issues in docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/mozilla/mozilla-django-oidc/issues.
+Report bugs at `<https://github.com/mozilla/mozilla-django-oidc/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -43,7 +43,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/mozilla/mozilla-django-oidc/issues.
+The best way to send feedback is to file an issue at `<https://github.com/mozilla/mozilla-django-oidc/issues>`_.
 
 If you are proposing a feature:
 
@@ -60,34 +60,34 @@ Ready to contribute? Here's how to set up `mozilla-django-oidc` for local develo
 1. Fork the `mozilla-django-oidc` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/mozilla-django-oidc.git
+       $ git clone git@github.com:your_name_here/mozilla-django-oidc.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv mozilla-django-oidc
-    $ cd mozilla-django-oidc/
-    $ python setup.py develop
+       $ mkvirtualenv mozilla-django-oidc
+       $ cd mozilla-django-oidc/
+       $ python setup.py develop
 
 4. Create a branch for local development::
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+       $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-        $ flake8 mozilla_django_oidc tests
-        $ python setup.py test
-        $ tox
+       $ flake8 mozilla_django_oidc tests
+       $ python setup.py test
+       $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv. 
 
 6. Commit your changes and push your branch to GitHub::
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+       $ git add .
+       $ git commit -m "Your detailed description of your changes."
+       $ git push origin name-of-your-bugfix-or-feature
 
 7. Submit a pull request through the GitHub website.
 
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check 
-   https://travis-ci.org/mozilla/mozilla-django-oidc/pull_requests
+   `<https://travis-ci.org/mozilla/mozilla-django-oidc/pull_requests>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=============================
+===================
 mozilla-django-oidc
-=============================
+===================
 
 .. image:: https://badge.fury.io/py/mozilla-django-oidc.png
     :target: https://badge.fury.io/py/mozilla-django-oidc
@@ -13,13 +13,15 @@ mozilla-django-oidc
 
 A lightweight authentication and access management library for integration with OpenID Connect enabled authentication services.
 
+
 Documentation
 -------------
 
-The full documentation is at https://mozilla-django-oidc.readthedocs.io.
+The full documentation is at `<https://mozilla-django-oidc.readthedocs.io>`_.
+
 
 Running Tests
---------------
+-------------
 
 Does the code actually work?
 
@@ -29,12 +31,15 @@ Does the code actually work?
     (myenv) $ pip install -r requirements/requirements_test.txt
     (myenv) $ python runtests.py
 
+
 License
---------
+-------
+
 This software is licensed under the MPL 2.0 license. For more info check the LICENSE file.
 
+
 Credits
----------
+-------
 
 Tools used in rendering this package:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -5,7 +5,7 @@ Settings
 This document describes the Django settings that can be used to customize the configuration
 of ``mozilla-django-oidc``.
 
-.. attribute:: SITE_URL
+.. py:attribute:: SITE_URL
 
    :default: No default
 
@@ -18,85 +18,85 @@ of ``mozilla-django-oidc``.
       long as they match what you are using to access your site.
 
 
-.. attribute:: OIDC_OP_AUTHORIZATION_ENDPOINT
+.. py:attribute:: OIDC_OP_AUTHORIZATION_ENDPOINT
 
    :default: No default
 
    URL of your OpenID Connect provider authorization endpoint.
 
-.. attribute:: OIDC_OP_TOKEN_ENDPOINT
+.. py:attribute:: OIDC_OP_TOKEN_ENDPOINT
 
    :default: No default
 
    URL of your OpenID Connect provider token endpoint
 
-.. attribute:: OIDC_OP_USER_ENDPOINT
+.. py:attribute:: OIDC_OP_USER_ENDPOINT
 
    :default: No default
 
    URL of your OpenID Connect provider userinfo endpoint
 
-.. attribute:: OIDC_RP_CLIENT_ID
+.. py:attribute:: OIDC_RP_CLIENT_ID
 
    :default: No default
 
    OpenID Connect client ID provided by your OP
 
-.. attribute:: OIDC_RP_CLIENT_SECRET
+.. py:attribute:: OIDC_RP_CLIENT_SECRET
 
    :default: No default
 
    OpenID Connect client secret provided by your OP
 
-.. attribute:: OIDC_RP_CLIENT_SECRET_ENCODED
+.. py:attribute:: OIDC_RP_CLIENT_SECRET_ENCODED
 
    :default: ``False``
 
    Controls whether your client secret requires base64 decoding for verification
 
-.. attribute:: OIDC_VERIFY_JWT
+.. py:attribute:: OIDC_VERIFY_JWT
 
    :default: ``True``
 
    Controls whether the OpenID Connect client verifies the signature of the JWT tokens
 
-.. attribute:: OIDC_USE_NONCE
+.. py:attribute:: OIDC_USE_NONCE
 
    :default: ``True``
 
    Controls whether the OpenID Connect client uses nonce verification
 
-.. attribute:: OIDC_VERIFY_SSL
+.. py:attribute:: OIDC_VERIFY_SSL
 
    :default: ``True``
 
    Controls whether the OpenID Connect client verifies the SSL certificate of the OP responses
 
-.. attribute:: OIDC_CREATE_USER
+.. py:attribute:: OIDC_CREATE_USER
 
    :default: ``True``
 
    Enables or disables automatic user creation during authentication
 
-.. attribute:: OIDC_STATE_SIZE
+.. py:attribute:: OIDC_STATE_SIZE
 
    :default: ``32``
 
    Sets the length of the random string used for OpenID Connect state verification
 
-.. attribute:: OIDC_NONCE_SIZE
+.. py:attribute:: OIDC_NONCE_SIZE
 
    :default: ``32``
 
    Sets the length of the random string used for OpenID Connect nonce verification
 
-.. attribute:: OIDC_REDIRECT_FIELD_NAME
+.. py:attribute:: OIDC_REDIRECT_FIELD_NAME
 
    :default: ``next``
 
    Sets the GET parameter that is being used to define the redirect URL after succesful authentication
 
-.. attribute:: OIDC_CALLBACK_CLASS
+.. py:attribute:: OIDC_CALLBACK_CLASS
 
    :default: ``mozilla_django_oidc.views.OIDCAuthenticationCallbackView``
 
@@ -108,21 +108,21 @@ of ``mozilla-django-oidc``.
       When using a custom callback view, it is generally a good idea to subclass the
       default ``OIDCAuthenticationCallbackView`` and override the methods you want to change.
 
-.. attribute:: LOGIN_REDIRECT_URL
+.. py:attribute:: LOGIN_REDIRECT_URL
 
     :default: ``/accounts/profile``
 
     Path to redirect to on successful login. If you don't specify this, the
     default Django value will be used.
 
-.. attribute:: LOGIN_REDIRECT_URL_FAILURE
+.. py:attribute:: LOGIN_REDIRECT_URL_FAILURE
 
     :default: ``/``
 
     Path to redirect to on an unsuccessful login attempt.
 
 
-.. attribute:: LOGOUT_REDIRECT_URL
+.. py:attribute:: LOGOUT_REDIRECT_URL
 
    :default: ``/``
 


### PR DESCRIPTION
This cleans up some Sphinx/reST formatting in the docs.

Seems like PyPI is displaying the long description correctly, but I've definitely seen it have issues with improperly formatted headers. This fixes those.

This adds url syntax around urls. While urls do get picked up and linkified, adding the url syntax makes it unlikely for the url link to pick up stray characters that are part of a sentence or something else.

"attribute" isn't a valid directive, but "py:attribute::" is and I'm pretty sure it's indexed, too.

Mostly this is cosmetic and doesn't change the meaning of anything.