### PR TITLE
Add support for Django 1.11 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"
@@ -22,6 +23,12 @@ matrix:
       env: DJANGO="Django<1.11"
     - python: "3.3"
       env: DJANGO="Django<1.12"
+    - python: "3.6"
+      env: DJANGO="Django<1.9"
+    - python: "3.6"
+      env: DJANGO="Django<1.10"
+    - python: "3.6"
+      env: DJANGO="Django<1.11"
 
 before_install:
   - pip install codecov

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,0 @@
-django>=1.9.6
-requests
-python-jose>=1.3.2

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,8 +1,7 @@
-# Include base requirements
--r requirements.txt
+# Install mozilla-django-oidc
+-e .
 
 bumpversion==0.5.3
 wheel==0.29.0
 ipython==5.1.0
 ipdb==0.10.1
-

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,6 +1,7 @@
-# Include base requirements.
--r requirements.txt
+# Install mozilla-django-oidc
+-e .
 
+# Test requirements
 coverage==4.2
 mock>=1.0.1
 flake8>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,11 @@ setup(
         'mozilla_django_oidc',
     ],
     include_package_data=True,
-    install_requires=['Django>1.7', 'python-jose', 'requests'],
+    install_requires=[
+        'Django>1.7',
+        'python-jose',
+        'requests'
+    ],
     license='MPL 2.0',
     zip_safe=False,
     keywords='mozilla-django-oidc',
@@ -54,6 +58,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -63,5 +68,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,15 @@ envlist =
     {py27,py33,py34,py35}-django18
     {py27,py34,py35}-django19
     {py27,py34,py35}-django110
+    {py27,py34,py35,py36}-django111
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/mozilla_django_oidc
 commands = python runtests.py
 deps =
-    django-18: Django>=1.8,<1.9
-    django-19: Django>=1.9,<1.10
-    django-110: Django>=1.10
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11
     -r{toxinidir}/requirements/requirements_test.txt


### PR DESCRIPTION
* add test environments covering Django 1.11 and Python 3.6
* fix tox environments so they test correctly
* remove requirements.txt which is an out-of-sync copy of what's in setup.py

Fixes #85.