### PR TITLE
Allow combining OIDCAuthenticationBackend with other backends.

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -88,7 +88,7 @@ class OIDCAuthenticationBackend(object):
 
         self.request = kwargs.pop('request', None)
         if not self.request:
-            raise SuspiciousOperation('Request object not found.')
+            return None
 
         state = self.request.GET.get('state')
         code = self.request.GET.get('code')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -22,6 +22,10 @@ class OIDCAuthenticationBackendTestCase(TestCase):
     def setUp(self):
         self.backend = OIDCAuthenticationBackend()
 
+    def test_missing_request_arg(self):
+        """Test authentication returns `None` when `request` is not provided."""
+        self.assertEqual(self.backend.authenticate(request=None), None)
+
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token')
     @patch('mozilla_django_oidc.auth.requests')
     def test_invalid_token(self, request_mock, token_mock):


### PR DESCRIPTION
* Return `None` if request not available in kwargs