### PR TITLE
Change email matching to be case-insensitive

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -57,7 +57,7 @@ class OIDCAuthenticationBackend(object):
         email = claims.get('email')
         if not email:
             return self.UserModel.objects.none()
-        return self.UserModel.objects.filter(email=email)
+        return self.UserModel.objects.filter(email__iexact=email)
 
     def create_user(self, claims):
         """Return object for a newly created user account."""


### PR DESCRIPTION
Emails aren't case sensitive, so we need to match the email address in the claim
with a Django user using a case-insensitive match.

This is part of issue #102.