### PR TITLE
[refactoring] smart_bytes exists in django 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Django of your choice. Here is such an example:
 
     $ virtualenv -p /path/to/bin/python3.5 venv
     $ source venv
-    (venv) $ pip install Django==1.11.1
+    (venv) $ pip install Django==1.11.2
     (venv) $ pip install -r tests/requirements.txt
     (venv) $ DJANGO_SETTINGS_MODULE=tests.settings django-admin.py test
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -4,8 +4,7 @@ import json
 import logging
 import requests
 
-from django.utils.encoding import smart_bytes
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_bytes, smart_text
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.core.urlresolvers import reverse

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -4,10 +4,7 @@ import json
 import logging
 import requests
 
-try:
-    from django.utils.encoding import smart_bytes
-except ImportError:
-    from django.utils.encoding import smart_str as smart_bytes
+from django.utils.encoding import smart_bytes
 from django.utils.encoding import smart_text
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -1,9 +1,10 @@
 import logging
 import time
 try:
-    from urllib import urlencode
-except ImportError:
     from urllib.parse import urlencode
+except ImportError:
+    # Python < 3
+    from urllib import urlencode
 
 import django
 from django.core.urlresolvers import reverse

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -1,8 +1,9 @@
 import time
 try:
-    from urllib import urlencode
-except ImportError:
     from urllib.parse import urlencode
+except ImportError:
+    # Python < 3
+    from urllib import urlencode
 
 from django.core.exceptions import SuspiciousOperation
 from django.core.urlresolvers import reverse

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 try:
     from setuptools import setup
 except ImportError:
+    # FIXME(peterbe): In what circumstances do you NOT have setuptools?
     from distutils.core import setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import sys
 try:
     from setuptools import setup
 except ImportError:
-    # FIXME(peterbe): In what circumstances do you NOT have setuptools?
     from distutils.core import setup
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -198,11 +198,9 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'redirect_uri': 'http://testserver/callback/',
         }
         self.assertEqual(User.objects.all().count(), 0)
-        result = self.backend.authenticate(request=auth_request)
+        self.backend.authenticate(request=auth_request)
         self.assertEqual(User.objects.all().count(), 1)
         user = User.objects.all()[0]
-        self.assertEquals(user, result)
-
         self.assertEquals(user.email, 'email@example.com')
         self.assertEquals(user.username, 'username_algo')
 
@@ -214,31 +212,6 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'}
         )
-
-    @patch('mozilla_django_oidc.auth.requests')
-    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token')
-    def test_successful_authentication_no_email(self, token_mock, request_mock):
-        """What happens if the auth "works" but it doesn't have an email?"""
-        auth_request = RequestFactory().get('/foo', {'code': 'foo',
-                                                     'state': 'bar'})
-        auth_request.session = {}
-
-        token_mock.return_value = True
-        get_json_mock = Mock()
-        get_json_mock.json.return_value = {
-            'nickname': 'a_username',
-            'email': ''
-        }
-        request_mock.get.return_value = get_json_mock
-        post_json_mock = Mock()
-        post_json_mock.json.return_value = {
-            'id_token': 'id_token',
-            'access_token': 'access_granted'
-        }
-        request_mock.post.return_value = post_json_mock
-        result = self.backend.authenticate(request=auth_request)
-        assert result is None
-        self.assertEqual(User.objects.all().count(), 0)
 
     def test_authenticate_no_code_no_state(self):
         """Test authenticate with wrong parameters."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ import time
 try:
     from urllib.parse import parse_qs
 except ImportError:
+    # Python < 3
     from urlparse import parse_qs
 
 from mock import patch

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,8 @@
 try:
-    from urlparse import parse_qs, urlparse
-except ImportError:
     from urllib.parse import parse_qs, urlparse
+except ImportError:
+    # Python < 3
+    from urlparse import parse_qs, urlparse
 
 from mock import patch
 


### PR DESCRIPTION
It occurred to me that `django.utils.encoding.smart_bytes` works all the way back in Django 1.8.

Also, I changed the `ImportError` tricks to always try Python 3 first. 