### PR TITLE
Add note about platform support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,5 @@
-.. complexity documentation master file, created by
-   sphinx-quickstart on Tue Jul  9 22:26:36 2013.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to mozilla-django-oidc's documentation!
-=================================================================
+===============================================
 
 Contents:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,12 @@ After installation, you'll need to do some things to get your site using
 ``mozilla-django-oidc``.
 
 
+Requirements
+------------
+
+This library supports Python 2.7 and 3.3+ on OSX and Linux.
+
+
 Acquire a client id and client secret
 -------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         'Framework :: Django :: 1.11',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Intended Audience :: Developers',
+        'Operating System :: MacOS',
+        'Operating System :: POSIX :: Linux',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
This adds the trove classifiers for OSX and Linux, but not Windows.

This adds a note to the installation chapter about supported Python versions and
platforms.

Does this look ok? I wondered whether to be explicit and say "We don't support Windows." or not. Would that be a better thing to have in the installation chapter?