### PR TITLE
Request the correct OpenIDC scopes

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -97,6 +97,12 @@ of ``mozilla-django-oidc``.
       When using a custom callback view, it is generally a good idea to subclass the
       default ``OIDCAuthenticationCallbackView`` and override the methods you want to change.
 
+.. py:attribute:: OIDC_RP_SCOPES
+
+   :default: ``openid email``
+
+   The OpenID Connect scopes to request during login.
+
 .. py:attribute:: LOGIN_REDIRECT_URL
 
    :default: ``/accounts/profile``

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -11,7 +11,11 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.crypto import get_random_string
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings, is_authenticated
+from mozilla_django_oidc.utils import (
+    absolutify,
+    import_from_settings,
+    is_authenticated
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -101,7 +105,7 @@ class RefreshIDToken(MiddlewareMixin):
                 reverse('oidc_authentication_callback')
             ),
             'state': state,
-            'scope': 'openid',
+            'scope': import_from_settings('OIDC_RP_SCOPES', 'openid email'),
             'prompt': 'none',
         }
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -18,7 +18,7 @@ from django.views.generic import View
 from mozilla_django_oidc.utils import (
     absolutify,
     import_from_settings,
-    is_authenticated,
+    is_authenticated
 )
 
 
@@ -124,7 +124,7 @@ class OIDCAuthenticationRequestView(View):
 
         params = {
             'response_type': 'code',
-            'scope': 'openid',
+            'scope': import_from_settings('OIDC_RP_SCOPES', 'openid email'),
             'client_id': self.OIDC_RP_CLIENT_ID,
             'redirect_uri': absolutify(
                 request,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -83,7 +83,7 @@ class RefreshIDTokenMiddlewareTestCase(TestCase):
             'client_id': ['foo'],
             'nonce': ['examplestring'],
             'prompt': ['none'],
-            'scope': ['openid'],
+            'scope': ['openid email'],
             'state': ['examplestring'],
         }
         self.assertEquals(expected_query, parse_qs(qs))
@@ -112,7 +112,7 @@ class RefreshIDTokenMiddlewareTestCase(TestCase):
             'client_id': ['foo'],
             'nonce': ['examplestring'],
             'prompt': ['none'],
-            'scope': ['openid'],
+            'scope': ['openid email'],
             'state': ['examplestring'],
         }
         self.assertEquals(expected_query, parse_qs(qs))
@@ -254,7 +254,7 @@ class MiddlewareTestCase(TestCase):
             'client_id': ['foo'],
             'nonce': ['examplestring'],
             'prompt': ['none'],
-            'scope': ['openid'],
+            'scope': ['openid email'],
             'state': ['examplestring'],
         }
         self.assertEquals(expected_query, parse_qs(qs))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -347,7 +347,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         o = urlparse(response.url)
         expected_query = {
             'response_type': ['code'],
-            'scope': ['openid'],
+            'scope': ['openid email'],
             'client_id': ['example_id'],
             'redirect_uri': ['http://testserver/callback/'],
             'state': ['examplestring'],


### PR DESCRIPTION
This patch makes the requested set of OpenID Connect scopes configurable, but
defaults to "openid email".

The "email" scope was never requested, which means that any privacy-sensitive
IdP would not send the users' email address.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>