### PR TITLE
OIDC_STORE_ACCESS_TOKEN doesn't (and isn't documented)

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -103,6 +103,18 @@ of ``mozilla-django-oidc``.
 
    The OpenID Connect scopes to request during login.
 
+.. py:attribute:: OIDC_STORE_ACCESS_TOKEN
+
+   :default: ``False``
+
+   If true, store the access_token in ``session['oidc_access_token']``.
+
+.. py:attribute:: OIDC_STORE_ID_TOKEN
+
+   :default: ``False``
+
+   If true, store the id_token in ``session['oidc_id_token']``.
+
 .. py:attribute:: LOGIN_REDIRECT_URL
 
    :default: ``/accounts/profile``

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -135,6 +135,9 @@ class OIDCAuthenticationBackend(object):
             access_token = token_response.get('access_token')
 
             if import_from_settings('OIDC_STORE_ACCESS_TOKEN', False):
+                session['oidc_access_token'] = access_token
+
+            if import_from_settings('OIDC_STORE_ID_TOKEN', False):
                 session['oidc_id_token'] = id_token
 
             user_response = requests.get(self.OIDC_OP_USER_ENDPOINT,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -126,6 +126,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             headers={'Authorization': 'Bearer access_granted'}
         )
 
+    @override_settings(OIDC_STORE_ACCESS_TOKEN=True)
+    @override_settings(OIDC_STORE_ID_TOKEN=True)
     @patch('mozilla_django_oidc.auth.requests')
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token')
     def test_successful_authentication_existing_user_upper_case(self, token_mock, request_mock):
@@ -166,6 +168,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'}
         )
+        self.assertEqual(auth_request.session.get('oidc_id_token'), 'id_token')
+        self.assertEqual(auth_request.session.get('oidc_access_token'), 'access_granted')
 
     @patch.object(settings, 'OIDC_USERNAME_ALGO')
     @patch('mozilla_django_oidc.auth.requests')


### PR DESCRIPTION
https://github.com/mozilla/mozilla-django-oidc/blob/02502ca99926493649beeab7a82cb8c8fc5144c2/mozilla_django_oidc/auth.py#L137-L138

This setting is undocumented, and seems to store the id_token, rather than the access token.  Is there a reason for that?  If not, do you mind a PR to fix it?