### PR TITLE
Allow configuration of additional auth parameters

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -124,6 +124,12 @@ of ``mozilla-django-oidc``.
    Controls whether the OpenID Connect client stores the OIDC ``id_token`` in the user session.
    The session key used to store the data is ``oidc_id_token``.
 
+.. py:attribute:: OIDC_AUTH_REQUEST_EXTRA_PARAMS
+
+   :default: `{}`
+
+   Additional parameters to include in the initial authorization request.
+
 .. py:attribute:: LOGIN_REDIRECT_URL
 
    :default: ``/accounts/profile``

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -133,6 +133,9 @@ class OIDCAuthenticationRequestView(View):
             'state': state,
         }
 
+        extra = import_from_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})
+        params.update(extra)
+
         if import_from_settings('OIDC_USE_NONCE', True):
             nonce = get_random_string(import_from_settings('OIDC_NONCE_SIZE', 32))
             params.update({

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -359,6 +359,34 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='https://server.example.com/auth')
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
+    @override_settings(OIDC_AUTH_REQUEST_EXTRA_PARAMS={'audience': 'some-api.example.com'})
+    @patch('mozilla_django_oidc.views.get_random_string')
+    def test_get_with_audience(self, mock_random_string):
+        """Test initiation of a successful OIDC attempt."""
+        mock_random_string.return_value = 'examplestring'
+        url = reverse('oidc_authentication_init')
+        request = self.factory.get(url)
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+        response = login_view(request)
+        self.assertEqual(response.status_code, 302)
+
+        o = urlparse(response.url)
+        expected_query = {
+            'response_type': ['code'],
+            'scope': ['openid email'],
+            'client_id': ['example_id'],
+            'redirect_uri': ['http://testserver/callback/'],
+            'state': ['examplestring'],
+            'nonce': ['examplestring'],
+            'audience': ['some-api.example.com'],
+        }
+        self.assertDictEqual(parse_qs(o.query), expected_query)
+        self.assertEqual(o.hostname, 'server.example.com')
+        self.assertEqual(o.path, '/auth')
+
+    @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='https://server.example.com/auth')
+    @override_settings(OIDC_RP_CLIENT_ID='example_id')
     def test_next_url(self):
         """Test that `next` url gets stored to user session."""
         url = reverse('oidc_authentication_init')


### PR DESCRIPTION
The audience parameter is included in the `aud` claim in the resulting
tokens, and can allow other RPs to authenticate the tokens as well.