### PR TITLE
Add path host injection unit-test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,3 +39,12 @@ class AbsolutifyTestCase(TestCase):
         ).get('/', SERVER_PORT=443)
         url = absolutify(req, '/foo/bar')
         self.assertEqual(url, 'https://testserver/foo/bar')
+
+
+    @override_settings(SECURE_PROXY_SSL_HEADER=('HTTP_X_FORWARDED_PROTO', 'https'))
+    def test_absolutify_path_host_injection(self):
+        req = RequestFactory(
+            HTTP_X_FORWARDED_PROTO='https'
+        ).get('/', SERVER_PORT=443)
+        url = absolutify(req, 'evil.com/bar')
+        self.assertEqual(url, 'https://testserver/evil.com/foo/bar')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,6 @@ class AbsolutifyTestCase(TestCase):
         url = absolutify(req, '/foo/bar')
         self.assertEqual(url, 'https://testserver/foo/bar')
 
-
     @override_settings(SECURE_PROXY_SSL_HEADER=('HTTP_X_FORWARDED_PROTO', 'https'))
     def test_absolutify_path_host_injection(self):
         req = RequestFactory(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,5 +46,5 @@ class AbsolutifyTestCase(TestCase):
         req = RequestFactory(
             HTTP_X_FORWARDED_PROTO='https'
         ).get('/', SERVER_PORT=443)
-        url = absolutify(req, 'evil.com/bar')
+        url = absolutify(req, 'evil.com/foo/bar')
         self.assertEqual(url, 'https://testserver/evil.com/foo/bar')


### PR DESCRIPTION
Adds a check to ensure absolutify cannot be tricked into going to an alternate address.