### PR TITLE
Revisit OIDC_STORE_{ACCESS,ID}_TOKEN config entries

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -103,6 +103,27 @@ of ``mozilla-django-oidc``.
 
    The OpenID Connect scopes to request during login.
 
+.. py:attribute:: OIDC_STORE_ACCESS_TOKEN
+
+   :default: ``False``
+
+   Controls whether the OpenID Connect client stores the OIDC ``access_token`` in the user session.
+   The session key used to store the data is ``oidc_access_token``.
+
+   By default we want to store as few credentials as possible so this feature defaults to ``False``
+   and it's use is discouraged.
+
+   .. warning::
+      This feature stores authentication information in the session. If used in combination with Django's
+      cookie-based session backend, those tokens will be visible in the browser's cookie store.
+
+.. py:attribute:: OIDC_STORE_ID_TOKEN
+
+   :default: ``False``
+
+   Controls whether the OpenID Connect client stores the OIDC ``id_token`` in the user session.
+   The session key used to store the data is ``oidc_id_token``.
+
 .. py:attribute:: LOGIN_REDIRECT_URL
 
    :default: ``/accounts/profile``

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -135,6 +135,9 @@ class OIDCAuthenticationBackend(object):
             access_token = token_response.get('access_token')
 
             if import_from_settings('OIDC_STORE_ACCESS_TOKEN', False):
+                session['oidc_access_token'] = access_token
+
+            if import_from_settings('OIDC_STORE_ID_TOKEN', False):
                 session['oidc_id_token'] = id_token
 
             user_response = requests.get(self.OIDC_OP_USER_ENDPOINT,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -126,6 +126,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             headers={'Authorization': 'Bearer access_granted'}
         )
 
+    @override_settings(OIDC_STORE_ACCESS_TOKEN=True)
+    @override_settings(OIDC_STORE_ID_TOKEN=True)
     @patch('mozilla_django_oidc.auth.requests')
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token')
     def test_successful_authentication_existing_user_upper_case(self, token_mock, request_mock):
@@ -166,6 +168,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'}
         )
+        self.assertEqual(auth_request.session.get('oidc_id_token'), 'id_token')
+        self.assertEqual(auth_request.session.get('oidc_access_token'), 'access_granted')
 
     @patch.object(settings, 'OIDC_USERNAME_ALGO')
     @patch('mozilla_django_oidc.auth.requests')


### PR DESCRIPTION
* Fix name issue with ``OIDC_STORE_ID_TOKEN`` (was ``OIDC_STORE_ACCESS_TOKEN``)
* Implement functionality to store ``access_token`` in user session and add
  config entry to control this feature