### PR TITLE
Switch to using josepy. Fix #180.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ setup(
     include_package_data=True,
     install_requires=[
         'Django>1.7',
-        'python-jose',
+        # cryptography dropped supporting Python 3.3 at some point
+        "cryptography<1.9; python_version == '3.3'",
+        "cryptography>=1.9; python_version == '2.7' or python_version > '3.4'",
+        'josepy',
         'requests'
     ],
     license='MPL 2.0',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,18 @@ if sys.argv[-1] == 'tag':
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
+install_requirements = [
+    'Django>1.7',
+    'josepy',
+    'requests'
+]
+# cryptography dropped supporting Python 3.2/3.3 at some point
+if sys.version_info[:2] > (2, 7) and sys.version_info[:2] < (3, 4):
+    install_requirements.append('cryptography<1.9')
+else:
+    install_requirements.append('cryptography>1.9')
+
+
 setup(
     name='mozilla-django-oidc',
     version=VERSION,
@@ -40,18 +52,9 @@ setup(
     author='Tasos Katsoulas, John Giannelos',
     author_email='akatsoulas@mozilla.com, jgiannelos@mozilla.com',
     url='https://github.com/mozilla/mozilla-django-oidc',
-    packages=[
-        'mozilla_django_oidc',
-    ],
+    packages=['mozilla_django_oidc'],
     include_package_data=True,
-    install_requires=[
-        'Django>1.7',
-        # cryptography dropped supporting Python 3.3 at some point
-        "cryptography<1.9; python_version == '3.3'",
-        "cryptography>=1.9; python_version == '2.7' or python_version > '3.4'",
-        'josepy',
-        'requests'
-    ],
+    install_requires=install_requirements,
     license='MPL 2.0',
     zip_safe=False,
     keywords='mozilla-django-oidc',

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -230,7 +230,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             self.backend.authenticate(request=request)
 
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_jwt_decode_params(self, request_mock, jws_mock):
         """Test jwt verification signature."""
@@ -255,13 +255,13 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.return_value = post_json_mock
         self.backend.authenticate(request=auth_request)
         calls = [
-            call('token', 'client_secret', algorithms=['HS256'])
+            call('token', 'client_secret', algorithm='HS256')
         ]
         jws_mock.assert_has_calls(calls)
 
     @override_settings(OIDC_VERIFY_JWT=False)
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_jwt_decode_params_verify_false(self, request_mock, jws_mock):
         """Test jwt verification signature with verify False"""
@@ -285,18 +285,18 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         }
         request_mock.post.return_value = post_json_mock
         calls = [
-            call('token', 'client_secret', algorithms=['HS256'])
+            call('token', 'client_secret', algorithm='HS256')
         ]
 
         self.backend.authenticate(request=auth_request)
         jws_mock.assert_has_calls(calls)
 
     @override_settings(OIDC_USE_NONCE=True)
-    @patch('mozilla_django_oidc.auth.jws')
-    def test_jwt_failed_nonce(self, jwt_mock):
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
+    def test_jwt_failed_nonce(self, jws_mock):
         """Test Nonce verification."""
 
-        jwt_mock.verify.return_value = json.dumps({
+        jws_mock.return_value = json.dumps({
             'nonce': 'foobar',
             'aud': 'aud'
         }).encode('utf-8')
@@ -306,7 +306,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
     @override_settings(OIDC_CREATE_USER=False)
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_create_user_disabled(self, request_mock, jws_mock):
         """Test with user creation disabled and no user found."""
@@ -331,7 +331,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.return_value = post_json_mock
         self.assertEqual(self.backend.authenticate(request=auth_request), None)
 
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     @override_settings(OIDC_USE_NONCE=False)
     def test_create_user_enabled(self, request_mock, jws_mock):
@@ -361,7 +361,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
     @patch.object(settings, 'OIDC_USERNAME_ALGO')
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_custom_username_algo(self, request_mock, jws_mock, algo_mock):
         """Test user creation with custom username algorithm."""
@@ -390,7 +390,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
                          User.objects.get(username='username_algo'))
 
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_duplicate_emails_exact(self, request_mock, jws_mock):
         """Test auth with two users having the same email."""
@@ -418,7 +418,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         self.assertEqual(self.backend.authenticate(request=auth_request), None)
 
     @override_settings(OIDC_USE_NONCE=False)
-    @patch('mozilla_django_oidc.auth.jws.verify')
+    @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
     def test_duplicate_emails_case_mismatch(self, request_mock, jws_mock):
         """Test auth with two users having the same email, with different case."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -255,7 +255,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.return_value = post_json_mock
         self.backend.authenticate(request=auth_request)
         calls = [
-            call('token', 'client_secret', algorithm='HS256')
+            call('token', 'client_secret')
         ]
         jws_mock.assert_has_calls(calls)
 
@@ -285,7 +285,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         }
         request_mock.post.return_value = post_json_mock
         calls = [
-            call('token', 'client_secret', algorithm='HS256')
+            call('token', 'client_secret')
         ]
 
         self.backend.authenticate(request=auth_request)


### PR DESCRIPTION
This adopts [josepy](https://github.com/jezdez/josepy) (formerly [acme.jose](https://github.com/certbot/certbot/tree/7c1115881012d62c9903c60a0fd57023b641b8d4/acme/acme/jose)) for the JOSE verification.

It also adds a bit of shim since the python-jose did a bit more in terms of verification, but that seems little compared to what we gain security wise.

I think it would make sense to try this out on a real website that uses this, as of now I don't have access to one myself.

Any helpers?