### PR TITLE
send bytes to josepy, fixes #189

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -4,7 +4,7 @@ import json
 import logging
 import requests
 
-from django.utils.encoding import smart_bytes, smart_text
+from django.utils.encoding import force_bytes, smart_text
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import SuspiciousOperation, ImproperlyConfigured
@@ -32,7 +32,7 @@ def default_username_algo(email):
     # this protects against data leakage because usernames are often
     # treated as public identifiers (so we can't use the email address).
     username = base64.urlsafe_b64encode(
-        hashlib.sha1(smart_bytes(email)).digest()
+        hashlib.sha1(force_bytes(email)).digest()
     ).rstrip(b'=')
 
     return smart_text(username)
@@ -110,8 +110,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         # Verify the token
         verified_token = self._verify_jws(
-            smart_bytes(token),
-            smart_bytes(key),
+            force_bytes(token),
+            force_bytes(key),
         )
         # The 'verified_token' will always be a byte string since it's
         # the result of base64.urlsafe_b64decode().

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -110,8 +110,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         # Verify the token
         verified_token = self._verify_jws(
-            token,
-            key,
+            smart_bytes(token),
+            smart_bytes(key),
         )
         # The 'verified_token' will always be a byte string since it's
         # the result of base64.urlsafe_b64decode().

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -4,7 +4,7 @@ import json
 import logging
 import requests
 
-from django.utils.encoding import force_bytes, smart_text
+from django.utils.encoding import force_bytes, smart_text, smart_bytes
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import SuspiciousOperation, ImproperlyConfigured
@@ -111,7 +111,8 @@ class OIDCAuthenticationBackend(ModelBackend):
         # Verify the token
         verified_token = self._verify_jws(
             force_bytes(token),
-            force_bytes(key),
+            # Use smart_bytes here since the key string comes from settings.
+            smart_bytes(key),
         )
         # The 'verified_token' will always be a byte string since it's
         # the result of base64.urlsafe_b64decode().

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -254,9 +254,14 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         }
         request_mock.post.return_value = post_json_mock
         self.backend.authenticate(request=auth_request)
-        calls = [
-            call('token', 'client_secret')
-        ]
+        if six.PY2:
+            calls = [
+                call('token', 'client_secret')
+            ]
+        else:
+            calls = [
+                call(b'token', b'client_secret')
+            ]
         jws_mock.assert_has_calls(calls)
 
     @override_settings(OIDC_VERIFY_JWT=False)
@@ -284,9 +289,16 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_token'
         }
         request_mock.post.return_value = post_json_mock
-        calls = [
-            call('token', 'client_secret')
-        ]
+        # Whichever Python version you use, always expect the jws_mock
+        # to be called with byte strings.
+        if six.PY2:
+            calls = [
+                call('token', 'client_secret')
+            ]
+        else:
+            calls = [
+                call(b'token', b'client_secret')
+            ]
 
         self.backend.authenticate(request=auth_request)
         jws_mock.assert_has_calls(calls)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils import six
+from django.utils.encoding import force_bytes
 
 from mozilla_django_oidc.auth import (
     default_username_algo,
@@ -254,14 +255,9 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         }
         request_mock.post.return_value = post_json_mock
         self.backend.authenticate(request=auth_request)
-        if six.PY2:
-            calls = [
-                call('token', 'client_secret')
-            ]
-        else:
-            calls = [
-                call(b'token', b'client_secret')
-            ]
+        calls = [
+            call(force_bytes('token'), force_bytes('client_secret'))
+        ]
         jws_mock.assert_has_calls(calls)
 
     @override_settings(OIDC_VERIFY_JWT=False)
@@ -289,17 +285,9 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_token'
         }
         request_mock.post.return_value = post_json_mock
-        # Whichever Python version you use, always expect the jws_mock
-        # to be called with byte strings.
-        if six.PY2:
-            calls = [
-                call('token', 'client_secret')
-            ]
-        else:
-            calls = [
-                call(b'token', b'client_secret')
-            ]
-
+        calls = [
+            call(force_bytes('token'), force_bytes('client_secret'))
+        ]
         self.backend.authenticate(request=auth_request)
         jws_mock.assert_has_calls(calls)
 


### PR DESCRIPTION
CC @jezdez @willkg 

With this fix, I can use mozilla-django-oidc 0.4.0 in my Python 3.6 project. 