### PR TITLE
The logout request object is passed to the OIDC_OP_LOGOUT_URL_METHOD

### DIFF
--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -170,7 +170,7 @@ class OIDCLogoutView(View):
             # from the OP.
             logout_from_op = import_from_settings('OIDC_OP_LOGOUT_URL_METHOD', '')
             if logout_from_op:
-                logout_url = import_string(logout_from_op)()
+                logout_url = import_string(logout_from_op)(request)
 
             # Log out the Django user if they were logged in.
             auth.logout(request)


### PR DESCRIPTION
This way, the method can use various parts of the request (mostly the session) to build the logout url.
For example, my idp requires the id token and that can be retrieved from the session attached to the request.