### PR TITLE
Add integration tests for mozilla-django-oidc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build_lib:
+    docker:
+      - image: circleci/python:3
+    steps:
+      - checkout
+      - run: mkdir workspace
+      - run: make sdist
+      - run: mv dist/mozilla-django-oidc-* workspace/mozilla-django-oidc-dev.tar.gz
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - mozilla-django-oidc-dev.tar.gz
+  test:
+    docker:
+      - image: mozillaparsys/oidc_testrp:py3
+        name: testrp
+      - image: mozillaparsys/oidc_testprovider
+        name: testprovider
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: pip install /tmp/workspace/mozilla-django-oidc-dev.tar.gz
+      - run:
+          command: ./bin/run_rs.sh
+          background: True
+      - run: python integration_tests.py

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  testprovider:
+    image: mozillaparsys/oidc_testprovider
+    ports:
+      - "8080:8080"
+    command: ./bin/run.sh
+  testrp:
+    image: mozillaparsys/oidc_testrp:py${RP_PYTHON_VERSION}
+    volumes:
+      - ./vendor:/vendor
+    links:
+      - "testprovider:testprovider"
+    ports:
+      - "8081:8081"
+    command: bash -c "pip install /vendor/mozilla-django-oidc-latest.tar.gz && ./bin/run_${VALIDATION_ALGO}.sh"
+volumes:
+  vendor:

--- a/integration_tests/integration_tests.py
+++ b/integration_tests/integration_tests.py
@@ -1,0 +1,88 @@
+import unittest
+
+from splinter import Browser
+
+
+class IntegrationTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(IntegrationTest, self).__init__(*args, **kwargs)
+
+        self.webdriver = 'phantomjs'
+        self.account = {
+            'username': 'example_username',
+            'password': 'example_p@ssw0rd',
+            'email': 'example@example.com'
+        }
+
+    def setUp(self):
+        """Create test account in `testprovider` instance"""
+        with Browser(self.webdriver) as browser:
+            browser.visit('http://testprovider:8080/account/signup')
+            browser.find_by_css('#id_username').fill(self.account['username'])
+            browser.find_by_css('#id_password').fill(self.account['password'])
+            browser.find_by_css('#id_password_confirm').fill(self.account['password'])
+            browser.find_by_css('#id_email').fill(self.account['email'])
+            browser.find_by_css('.btn-primary').click()
+
+    def tearDown(self):
+        """Remove test account from `testprovider` instance"""
+        with Browser(self.webdriver) as browser:
+            self.perform_login(browser)
+            browser.visit('http://testprovider:8080/account/delete')
+            browser.find_by_css('.btn-danger').click()
+
+    def perform_login(self, browser):
+        """Perform login using webdriver"""
+        browser.visit('http://testrp:8081')
+        browser.find_by_css('div > a').click()
+        browser.find_by_css('#id_username').fill(self.account['username'])
+        browser.find_by_css('#id_password').fill(self.account['password'])
+        browser.find_by_css('.btn-primary').click()
+
+    def perform_logout(self, browser):
+        """Perform logout using webdriver"""
+        browser.visit('http://testrp:8081')
+        browser.find_by_css('input[value="Logout"]').click()
+
+    def test_login(self):
+        """Test logging in `testrp` using OIDC"""
+        browser = Browser(self.webdriver)
+
+        # Check that user is not logged in
+        browser.visit('http://testrp:8081')
+        self.assertTrue(browser.is_text_not_present('Current user:'))
+
+        # Perform login
+        self.perform_login(browser)
+
+        # Accept scope
+        browser.find_by_css('input[name="allow"]').click()
+
+        # Check that user is now logged in
+        self.assertTrue(browser.is_text_present('Current user:'))
+
+    def test_logout(self):
+        """Test logout functionality of OIDC lib"""
+        browser = Browser(self.webdriver)
+
+        # Check that user is not logged in
+        browser.visit('http://testrp:8081')
+        self.assertTrue(browser.is_text_not_present('Current user:'))
+
+        self.perform_login(browser)
+
+        # Accept scope
+        browser.find_by_css('input[name="allow"]').click()
+
+        # Check that user is now logged in
+        self.assertTrue(browser.is_text_present('Current user:'))
+
+        self.perform_logout(browser)
+
+        # Check that user is now logged out
+        self.assertTrue(browser.is_text_not_present('Current user:'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# Build a new package of mozilla-django-oidc lib
+cd ..
+make clean
+make sdist
+rm -rf integration_tests/vendor/
+mkdir integration_tests/vendor
+mv dist/*.tar.gz integration_tests/vendor/mozilla-django-oidc-latest.tar.gz
+
+# Build and run docker images for `testrp` and `testprovider`
+cd integration_tests
+docker-compose build
+docker-compose up -d
+sleep 10
+
+# Run integration tests
+python integration_tests.py
+
+# Cleanup env
+docker-compose stop
+docker-compose rm -f


### PR DESCRIPTION
* Uses prebuild docker images:
  * Test OIDC provider and OIDC RP images
  * Preseeded test credentials
* Use splinter /w phantomjs to perform automated integration tests
* Add tox entries to run integration tests