### PR TITLE
Update user claims

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -297,7 +297,7 @@ Changing how Django users are created
 If your website needs to do other bookkeeping things when a new ``User`` record
 is created, then you should subclass the
 :py:class:`mozilla_django_oidc.auth.OIDCAuthenticationBackend` class and
-override the `create_user` method.
+override the `create_user` method, and optionally, the `update_user` method.
 
 For example, let's say you want to populate the ``User`` instance with other
 data from the claims:
@@ -311,6 +311,13 @@ data from the claims:
        def create_user(self, claims):
            user = super(MyOIDCAB, self).create_user(claims)
 
+           user.first_name = claims.get('given_name', '')
+           user.last_name = claims.get('family_name', '')
+           user.save()
+
+           return user
+
+       def update_user(self, user, claims):
            user.first_name = claims.get('given_name', '')
            user.last_name = claims.get('family_name', '')
            user.save()

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -311,8 +311,9 @@ data from the claims:
        def create_user(self, claims):
            user = super(MyOIDCAB, self).create_user(claims)
 
-           user.first_name = claim.get('given_name', '')
-           user.last_name = claim.get('family_name', '')
+           user.first_name = claims.get('given_name', '')
+           user.last_name = claims.get('family_name', '')
+           user.save()
 
            return user
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -91,6 +91,10 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         return self.UserModel.objects.create_user(username, email)
 
+    def update_user(self, user, claims):
+        """Update existing user with new claims, if necessary save, and return user"""
+        return user
+
     def _verify_jws(self, payload, key):
         """Verify the given JWS payload with the given key and return the payload"""
 
@@ -203,7 +207,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             users = self.filter_users_by_claims(user_info)
 
             if len(users) == 1:
-                return users[0]
+                return self.update_user(users[0], user_info)
             elif len(users) > 1:
                 # In the rare case that two user accounts have the same email address,
                 # log and bail. Randomly selecting one seems really wrong.


### PR DESCRIPTION
In addition to being able to override `OIDCAuthenticationBackend.create_user` to define specific mappings when creating a user, I want to be able to consume and store updates about that user from the identity provider.  

Therefore, before we return a successfully authenticated user, we pass to a new `OIDCAuthenticationBackend.update_user` method.  

Currently, `update_user` does not do anything to preserve default behavior, but subclasses of OIDCAuthenticationBackend can override to provide new behavior.  

For instance:

```python
class MyOIDCAB(OIDCAuthenticationBackend):
    def create_user(self, claims):
        user = super(MyOIDCAB, self).create_user(claims)

        user.first_name = claim.get('given_name', '')
        user.last_name = claim.get('family_name', '')
        user.save()

        return user

    def update_user(self, user, claims):
        user.first_name = claim.get('given_name', '')
        user.last_name = claim.get('family_name', '')
        user.save()
      
       return user
```

A smarter implementation of the example would check to see if the claims would change the user's attributes, and may re-use the mapping in both `update_user` and `create_user`.

Also included a small documentation update, since the user must be saved in `create_user`.