### PR TITLE
get_extra_params and OIDC_AUTHENTICATE_CLASS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -97,6 +97,18 @@ of ``mozilla-django-oidc``.
       When using a custom callback view, it is generally a good idea to subclass the
       default ``OIDCAuthenticationCallbackView`` and override the methods you want to change.
 
+.. py:attribute:: OIDC_AUTHENTICATE_CLASS
+
+   :default: ``mozilla_django_oidc.views.OIDCAuthenticationRequestView``
+
+   Allows you to substitute a custom class-based view to be used as OpenID Connect
+   authenticate URL.
+
+   .. note::
+
+      When using a custom authenticate view, it is generally a good idea to subclass the
+      default ``OIDCAuthenticationRequestView`` and override the methods you want to change.
+
 .. py:attribute:: OIDC_RP_SCOPES
 
    :default: ``openid email``

--- a/mozilla_django_oidc/urls.py
+++ b/mozilla_django_oidc/urls.py
@@ -9,10 +9,18 @@ CALLBACK_CLASS_PATH = import_from_settings('OIDC_CALLBACK_CLASS', DEFAULT_CALLBA
 
 OIDCCallbackClass = import_string(CALLBACK_CLASS_PATH)
 
+
+DEFAULT_AUTHENTICATE_CLASS = 'mozilla_django_oidc.views.OIDCAuthenticationRequestView'
+AUTHENTICATE_CLASS_PATH = import_from_settings(
+    'OIDC_AUTHENTICATE_CLASS', DEFAULT_AUTHENTICATE_CLASS
+)
+
+OIDCAuthenticateClass = import_string(AUTHENTICATE_CLASS_PATH)
+
 urlpatterns = [
     url(r'^callback/$', OIDCCallbackClass.as_view(),
         name='oidc_authentication_callback'),
-    url(r'^authenticate/$', views.OIDCAuthenticationRequestView.as_view(),
+    url(r'^authenticate/$', OIDCAuthenticateClass.as_view(),
         name='oidc_authentication_init'),
     url(r'^logout/$', views.OIDCLogoutView.as_view(), name='oidc_logout'),
 ]

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -137,8 +137,7 @@ class OIDCAuthenticationRequestView(View):
             'state': state,
         }
 
-        extra = import_from_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})
-        params.update(extra)
+        params.update(self.get_extra_params(request))
 
         if import_from_settings('OIDC_USE_NONCE', True):
             nonce = get_random_string(import_from_settings('OIDC_NONCE_SIZE', 32))
@@ -153,6 +152,9 @@ class OIDCAuthenticationRequestView(View):
         query = urlencode(params)
         redirect_url = '{url}?{query}'.format(url=self.OIDC_OP_AUTH_ENDPOINT, query=query)
         return HttpResponseRedirect(redirect_url)
+
+    def get_extra_params(self, request):
+        return import_from_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})
 
 
 class OIDCLogoutView(View):


### PR DESCRIPTION
I am using Auth0 and need a way to pass the `?connection=` parameter to hint to Auth0 which Identity Provider to use (of which there will be multiple).  

`OIDC_AUTH_REQUEST_EXTRA_PARAMS` would work if I only had one connection option, but I need to dynamically decide which connection param I want to use in the extra params.

Therefore, I have implemented two hooks to allow this behavior:
* `OIDCAuthenticationRequestView.get_extra_params` provides the `OIDC_AUTH_REQUEST_EXTRA_PARAMS`, but allows a subclass to override and dynamically change based upon the `request`
* `OIDC_AUTHENTICATE_CLASS` (modeled after `OIDC_CALLBACK_CLASS`) to allow registering a custom subclass as the view to use for the url.  I debated the naming on this, but picked it to match the `/authenticate/` URL, so as to avoid confusion as being the Authentication backend class.