### PR TITLE
used cached_property on exempt_urls

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -196,7 +196,7 @@ class MiddlewareTestCase(TestCase):
     def test_get_exempt_urls_setting_view_name(self):
         middleware = RefreshIDToken()
         self.assertEquals(
-            sorted(middleware.get_exempt_urls()),
+            sorted(list(middleware.exempt_urls)),
             [u'/authenticate/', u'/callback/', u'/logout/', u'/mdo_fake_view/']
         )
 
@@ -204,7 +204,7 @@ class MiddlewareTestCase(TestCase):
     def test_get_exempt_urls_setting_url_path(self):
         middleware = RefreshIDToken()
         self.assertEquals(
-            sorted(middleware.get_exempt_urls()),
+            sorted(list(middleware.exempt_urls)),
             [u'/authenticate/', u'/callback/', u'/foo/', u'/logout/']
         )
 


### PR DESCRIPTION
One thing that hurt my eye when I looked through the code is that we compute a list of URLs on every single request. Even when the list is never even used. 
It's pretty much CPU-bound so it wasn't horribly slow but it hurt to see it go to waste.

This PR makes the computation of all `exempt_urls` a once-per-processor thing. 
It also changes to a set which is faster to look for an item in. 
Lastly it rearranges the order so the comparison of `request.path` with the exempt URLs happens last. 