### PR TITLE
Return `None` when authenticate() request has no `state` or `code`

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -157,7 +157,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         session = self.request.session
 
         if not code or not state:
-            raise SuspiciousOperation('Code or state not found.')
+            return None
 
         reverse_url = import_from_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
                                            'oidc_authentication_callback')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -317,8 +317,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         # there are no GET params
         request = RequestFactory().get('/foo')
         request.session = {}
-        with self.assertRaisesMessage(SuspiciousOperation, 'Code or state not found'):
-            self.backend.authenticate(request=request)
+        self.assertIsNone(self.backend.authenticate(request=request))
 
     @override_settings(OIDC_USE_NONCE=False)
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')


### PR DESCRIPTION
In order for the OIDCAuthenticationBackend to be combined with other auth
backends it needs to return `None` when the call arguments are not targeting
this specific backend. This way we allow Django to try the next available
backend defined in settings.