### PR TITLE
implement authentication class for DRF

### DIFF
--- a/docs/drf.rst
+++ b/docs/drf.rst
@@ -26,4 +26,4 @@ figure that out. Alternatively, you can manually set the OIDC backend to use:
 
 .. code-block:: python
 
-	OIDC_AUTH_BACKEND = 'mozilla_django_oidc.OIDCAuthenticationBackend'
+	OIDC_DRF_AUTH_BACKEND = 'mozilla_django_oidc.OIDCAuthenticationBackend'

--- a/docs/drf.rst
+++ b/docs/drf.rst
@@ -1,0 +1,29 @@
+=======================================
+DRF (Django REST Framework) integration
+=======================================
+
+If you want DRF to authenticate users based on an OAuth access token provided in
+the ``Authorization`` header, you can use the DRF-specific authentication class
+which ships with the package.
+
+Add this to your settings:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        'DEFAULT_AUTHENTICATION_CLASSES': [
+            'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
+            # other authentication classes, if needed
+        ],
+    }
+
+Note that this only takes care of authenticating against an access token, and
+provides no options to create or renew tokens.
+
+If you've created a custom Django ``OIDCAuthenticationBackend`` and added that
+to your ``AUTHENTICATION_BACKENDS``, the DRF class should be smart enough to
+figure that out. Alternatively, you can manually set the OIDC backend to use:
+
+.. code-block:: python
+
+	OIDC_AUTH_BACKEND = 'mozilla_django_oidc.OIDCAuthenticationBackend'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
    installation
    settings
    xhr
+   drf
    contributing
    authors
    history

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -245,7 +245,11 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         if verified_id:
             self.store_tokens(access_token, id_token)
-            return self.get_or_create_user(access_token, id_token, verified_id)
+            try:
+                return self.get_or_create_user(access_token, id_token, verified_id)
+            except SuspiciousOperation as exc:
+                LOGGER.warning('failed to get or create user: %s', exc)
+                return None
 
         return None
 
@@ -269,8 +273,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         claims_verified = self.verify_claims(user_info)
         if not claims_verified:
-            LOGGER.debug('Login failed: Claims verification for %s failed.', email)
-            return None
+            msg = 'Claims verification for %s failed.' % email
+            raise SuspiciousOperation(msg)
 
         # email based filtering
         users = self.filter_users_by_claims(user_info)
@@ -279,9 +283,9 @@ class OIDCAuthenticationBackend(ModelBackend):
             return self.update_user(users[0], user_info)
         elif len(users) > 1:
             # In the rare case that two user accounts have the same email address,
-            # log and bail. Randomly selecting one seems really wrong.
-            LOGGER.warn('Multiple users with email address %s.', email)
-            return None
+            # bail. Randomly selecting one seems really wrong.
+            msg = 'Multiple users with email address %s.' % email
+            raise SuspiciousOperation(msg)
         elif import_from_settings('OIDC_CREATE_USER', True):
             user = self.create_user(user_info)
             return user

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -273,7 +273,7 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         claims_verified = self.verify_claims(user_info)
         if not claims_verified:
-            msg = 'Claims verification for %s failed.' % email
+            msg = 'Claims verification failed'
             raise SuspiciousOperation(msg)
 
         # email based filtering
@@ -284,7 +284,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         elif len(users) > 1:
             # In the rare case that two user accounts have the same email address,
             # bail. Randomly selecting one seems really wrong.
-            msg = 'Multiple users with email address %s.' % email
+            msg = 'Multiple users returned'
             raise SuspiciousOperation(msg)
         elif import_from_settings('OIDC_CREATE_USER', True):
             user = self.create_user(user_info)

--- a/mozilla_django_oidc/contrib/drf.py
+++ b/mozilla_django_oidc/contrib/drf.py
@@ -26,24 +26,22 @@ def get_oidc_backend():
     # allow the user to force which back backend to use. this is mostly
     # convenient if you want to use OIDC with DRF but don't want to configure
     # OIDC for the "normal" Django auth.
-    backend_setting = import_from_settings('OIDC_AUTH_BACKEND', None)
+    backend_setting = import_from_settings('OIDC_DRF_AUTH_BACKEND', None)
     if backend_setting:
         backend = import_string(backend_setting)()
         if not isinstance(backend, OIDCAuthenticationBackend):
-            msg = 'Class configured in OIDC_AUTH_BACKEND ' \
+            msg = 'Class configured in OIDC_DRF_AUTH_BACKEND ' \
                   'does not extend OIDCAuthenticationBackend!'
             raise ImproperlyConfigured(msg)
         return backend
 
     # if the backend setting is not set, look through the list of configured
     # backends for one that is an OIDCAuthenticationBackend.
-    backends = [
-        backend for backend in get_backends()
-        if isinstance(backend, OIDCAuthenticationBackend)
-    ]
+    backends = [b for b in get_backends() if isinstance(b, OIDCAuthenticationBackend)]
+
     if not backends:
         msg = 'No backends extending OIDCAuthenticationBackend found - ' \
-              'add one to AUTHENTICATION_BACKENDS or set OIDC_AUTH_BACKEND!'
+              'add one to AUTHENTICATION_BACKENDS or set OIDC_DRF_AUTH_BACKEND!'
         raise ImproperlyConfigured(msg)
     if len(backends) > 1:
         raise ImproperlyConfigured('More than one OIDCAuthenticationBackend found!')

--- a/mozilla_django_oidc/contrib/drf.py
+++ b/mozilla_django_oidc/contrib/drf.py
@@ -1,0 +1,132 @@
+"""
+Classes/functions for integrating with Django REST Framework.
+
+http://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
+"""
+
+import logging
+
+from django.contrib.auth import get_backends
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
+from django.utils.module_loading import import_string
+from rest_framework import authentication, exceptions
+from requests.exceptions import HTTPError
+
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from mozilla_django_oidc.utils import import_from_settings, parse_www_authenticate_header
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_oidc_backend():
+    """
+    Get the Django auth backend that uses OIDC.
+    """
+
+    # allow the user to force which back backend to use. this is mostly
+    # convenient if you want to use OIDC with DRF but don't want to configure
+    # OIDC for the "normal" Django auth.
+    backend_setting = import_from_settings('OIDC_AUTH_BACKEND', None)
+    if backend_setting:
+        backend = import_string(backend_setting)()
+        if not isinstance(backend, OIDCAuthenticationBackend):
+            msg = 'Class configured in OIDC_AUTH_BACKEND ' \
+                  'does not extend OIDCAuthenticationBackend!'
+            raise ImproperlyConfigured(msg)
+        return backend
+
+    # if the backend setting is not set, look through the list of configured
+    # backends for one that is an OIDCAuthenticationBackend.
+    backends = [
+        backend for backend in get_backends()
+        if isinstance(backend, OIDCAuthenticationBackend)
+    ]
+    if not backends:
+        msg = 'No backends extending OIDCAuthenticationBackend found - ' \
+              'add one to AUTHENTICATION_BACKENDS or set OIDC_AUTH_BACKEND!'
+        raise ImproperlyConfigured(msg)
+    if len(backends) > 1:
+        raise ImproperlyConfigured('More than one OIDCAuthenticationBackend found!')
+    return backends[0]
+
+
+class OIDCAuthentication(authentication.BaseAuthentication):
+    """
+    Provide OpenID authentication for DRF.
+    """
+
+    # used by the authenticate_header method.
+    www_authenticate_realm = 'api'
+
+    def __init__(self, backend=None):
+        self.backend = backend or get_oidc_backend()
+
+    def authenticate(self, request):
+        """
+        Authenticate the request and return a tuple of (user, token) or None
+        if there was no authentication attempt.
+        """
+        access_token = self.get_access_token(request)
+
+        if not access_token:
+            return None
+
+        try:
+            user = self.backend.get_or_create_user(access_token, None, None)
+        except HTTPError as exc:
+            resp = exc.response
+
+            # if the oidc provider returns 401, it means the token is invalid.
+            # in that case, we want to return the upstream error message (which
+            # we can get from the www-authentication header) in the response.
+            if resp.status_code == 401 and 'www-authenticate' in resp.headers:
+                data = parse_www_authenticate_header(resp.headers['www-authenticate'])
+                raise exceptions.AuthenticationFailed(data['error_description'])
+
+            # for all other http errors, just re-raise the exception.
+            raise
+        except SuspiciousOperation as exc:
+            LOGGER.info('Login failed: %s', exc)
+            raise exceptions.AuthenticationFailed('Login failed')
+
+        if not user:
+            msg = 'Login failed: No user found for the given access token.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        return user, access_token
+
+    def get_access_token(self, request):
+        """
+        Get the access token based on a request.
+
+        Returns None if no authentication details were provided. Raises
+        AuthenticationFailed if the token is incorrect.
+        """
+        header = authentication.get_authorization_header(request)
+        if not header:
+            return None
+        header = header.decode(authentication.HTTP_HEADER_ENCODING)
+
+        auth = header.split()
+
+        if auth[0].lower() != 'bearer':
+            return None
+
+        if len(auth) == 1:
+            msg = 'Invalid "bearer" header: No credentials provided.'
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = 'Invalid "bearer" header: Credentials string should not contain spaces.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth[1]
+
+    def authenticate_header(self, request):
+        """
+        If this method returns None, a generic HTTP 403 forbidden response is
+        returned by DRF when authentication fails.
+
+        By making the method return a string, a 401 is returned instead. The
+        return value will be used as the WWW-Authenticate header.
+        """
+        return 'Bearer realm="%s"' % self.www_authenticate_realm

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -1,6 +1,21 @@
+try:
+    from urllib.request import parse_http_list, parse_keqv_list
+except ImportError:
+    # python < 3
+    from urllib2 import parse_http_list, parse_keqv_list
+
 from django import VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
+
+def parse_www_authenticate_header(header):
+    """
+    Convert a WWW-Authentication header into a dict that can be used
+    in a JSON response.
+    """
+    items = parse_http_list(header)
+    return parse_keqv_list(items)
 
 
 def import_from_settings(attr, *args):

--- a/tests/test_contrib_drf.py
+++ b/tests/test_contrib_drf.py
@@ -1,0 +1,39 @@
+import mock
+
+from django.core.exceptions import SuspiciousOperation
+from django.test import RequestFactory, TestCase, override_settings
+from rest_framework import exceptions
+
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
+
+
+class TestDRF(TestCase):
+    @override_settings(OIDC_OP_TOKEN_ENDPOINT='https://server.example.com/token')
+    @override_settings(OIDC_OP_USER_ENDPOINT='https://server.example.com/user')
+    @override_settings(OIDC_RP_CLIENT_ID='example_id')
+    @override_settings(OIDC_RP_CLIENT_SECRET='client_secret')
+    def setUp(self):
+        self.auth = OIDCAuthentication(backend=mock.Mock())
+        self.request = RequestFactory().get('/', HTTP_AUTHORIZATION='Bearer faketoken')
+
+    def test_authenticate_returns_none_if_no_access_token(self):
+        with mock.patch.object(self.auth, 'get_access_token', return_value=None):
+            ret = self.auth.authenticate(self.request)
+        self.assertEqual(ret, None)
+
+    def test_authenticate_raises_authenticationfailed_if_backend_returns_no_user(self):
+        self.auth.backend.get_or_create_user.return_value = None
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            self.auth.authenticate(self.request)
+
+    def test_authenticate_raises_authenticationfailed_on_suspiciousoperation(self):
+        self.auth.backend.get_or_create_user.side_effect = SuspiciousOperation
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            self.auth.authenticate(self.request)
+
+    def test_returns_user_and_token_if_backend_returns_user(self):
+        user = mock.Mock()
+        self.auth.backend.get_or_create_user.return_value = user
+        ret = self.auth.authenticate(self.request)
+        self.assertEqual(ret[0], user)
+        self.assertEqual(ret[1], 'faketoken')

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ setenv =
 deps =
     -r{toxinidir}/tests/requirements.txt
     django111: Django>=1.11,<2.0.0
+    django111: djangorestframework>=3.4
     django200: Django>=2.0.0
+    django200: djangorestframework>=3.7
 
 [testenv:coverage]
 commands =
@@ -28,6 +30,7 @@ deps =
     coverage
     -r{toxinidir}/tests/requirements.txt
     Django>=1.11
+    djangorestframework>=3.4
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Related issue: https://github.com/mozilla/mozilla-django-oidc/issues/227

Mostly this involves refactoring the part that transforms a request (specifically its `Authorization` header) into a user object, so that there's a method you can use for *only* retrieving the user, which can then be re-used in the stateless/session-less DRF authentication class.

While working on this I found some minor issues which I extraced into smaller individual PRs. This PR depends on these, and I will rebase this PR when/if those are merged:

- [x] ~#233~ #241 
- [x] #234 