### PR TITLE
problem: retrieve_matching_jwk breaks when multiple keys are returned

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -148,10 +148,11 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         key = None
         for jwk in jwks['keys']:
+            if jwk['kid'] != smart_text(header.kid):
+                continue
             if 'alg' in jwk and jwk['alg'] != smart_text(header.alg):
                 raise SuspiciousOperation('alg values do not match.')
-            if jwk['kid'] == smart_text(header.kid):
-                key = jwk
+            key = jwk
         if key is None:
             raise SuspiciousOperation('Could not find a valid JWKS.')
         return key

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -839,6 +839,10 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
                 {
                     "alg": "RS256",
                     "kid": "foobar",
+                },
+                {
+                    "alg": "RS512",
+                    "kid": "foobar512",
                 }
             ]
         }
@@ -878,7 +882,7 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         }
         mock_requests.get.return_value = get_json_mock
 
-        header = force_bytes(json.dumps({'alg': 'HS256', 'typ': 'JWT', 'kid': 'foobar'}))
+        header = force_bytes(json.dumps({'alg': 'HS256', 'typ': 'JWT', 'kid': 'bar'}))
         payload = force_bytes(json.dumps({'foo': 'bar'}))
 
         # Compute signature


### PR DESCRIPTION
When looping over the keys in retrieve_matching_jwk it needs to first
skip over any key whose kid does not match BEFORE it checks if the alg
matches.  Otherwise at least one of the keys will not match and
SuspiciousOperation will be raised for every response.