### PR TITLE
only deploy on python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,5 @@ deploy:
     on:
       repo: mozilla/mozilla-django-oidc
       tags: true
+      python: '3.6'
     distributions: "sdist bdist_wheel"


### PR DESCRIPTION
I got the idea from https://github.com/pmclanahan/django-celery-email/commit/6d0684b3d2d6751c4e5066f9215e130e6a91ea78

At the moment, tag builds in Travis fail on all except Python 2.7. 
https://travis-ci.org/mozilla/mozilla-django-oidc/builds/420109398
The others shouldn't fail and we should probably be relying on a modern Python instead. 