### PR TITLE
Adds settings to control redirect behavior

### DIFF
--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -115,11 +115,13 @@ def get_next_url(request, redirect_field_name):
 
         # NOTE(robhudson): Django 2.1 changes `host` to `allowed_hosts`.
         if django.VERSION >= (2, 1):
-            hosts = tuple(getattr(settings, 'OIDC_REDIRECT_ALLOWED_HOSTS', ())) + (request.get_host(),)
+            hosts = tuple(getattr(settings, 'OIDC_REDIRECT_ALLOWED_HOSTS', ()))
+            hosts = hosts + (request.get_host(),)
             kwargs['allowed_hosts'] = hosts
         else:
             parsed_uri = urlparse(next_url)
-            allowed_hosts = tuple(getattr(settings, 'OIDC_REDIRECT_ALLOWED_HOSTS', ())) + (request.get_host(),)
+            allowed_hosts = tuple(getattr(settings, 'OIDC_REDIRECT_ALLOWED_HOSTS', ()))
+            allowed_hosts = allowed_hosts + (request.get_host(),)
             if parsed_uri.netloc in allowed_hosts:
                 host = parsed_uri.netloc
             else:

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -126,7 +126,6 @@ def get_next_url(request, redirect_field_name):
             kwargs['host'] = host
 
         is_safe = is_safe_url(**kwargs)
-        raise Exception(kwargs, is_safe)
         if is_safe:
             return next_url
     return None

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -122,13 +122,11 @@ def get_next_url(request, redirect_field_name):
             parsed_uri = urlparse(next_url)
             allowed_hosts = tuple(getattr(settings, 'OIDC_REDIRECT_ALLOWED_HOSTS', ()))
             allowed_hosts = allowed_hosts + (request.get_host(),)
-            if parsed_uri.netloc in allowed_hosts:
-                host = parsed_uri.netloc
-            else:
-                host = request.get_host()
+            host = parsed_uri.netloc if parsed_uri.netloc in allowed_hosts else request.get_host()
             kwargs['host'] = host
 
         is_safe = is_safe_url(**kwargs)
+        raise Exception(kwargs, is_safe)
         if is_safe:
             return next_url
     return None


### PR DESCRIPTION
We ran into some issues integrating mozilla-django-oidc because our client application is hosted on a subdomain. We could not redirect back to the previous URL because it was not on the same domain as the django app and therefore failed the `is_safe()` check in `mozilla_django_oidc.views.get_next_url`.

That check requires that the redirect URL be on the same domain (a problem for us) AND that it use HTTPS if the django site uses HTTPS (great for production, not so great for local development when there client app is running on localhost).

So this PR adds 2 new settings: 

OIDC_REDIRECT_REQUIRE_HTTPS=True|False (defaults to the current `request.is_secure()` behavior 
OIDC_REDIRECT_ALLOWED_HOSTS=tuple|list of hostnames

This allows us to whitelist our client app domain and also supports some flexibility during local development. Thank you!