### PR TITLE
Verify email is in claims before creating user

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -74,17 +74,12 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def verify_claims(self, claims):
         """Verify the provided claims to decide if authentication should be allowed."""
-        return True
+        return 'email' in claims
 
     def create_user(self, claims):
         """Return object for a newly created user account."""
-
         email = claims.get('email')
-        if not email:
-            return None
-
         username = self.get_username(claims)
-
         return self.UserModel.objects.create_user(username, email)
 
     def get_username(self, claims):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1009,5 +1009,17 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         self.assertEqual(ctx.exception.args[0], 'Could not find a valid JWKS.')
 
 
+class TestVerifyClaim(TestCase):
+    @patch('mozilla_django_oidc.auth.import_from_settings')
+    def test_returns_false_if_email_not_in_claims(self, _):
+        ret = OIDCAuthenticationBackend().verify_claims({})
+        self.assertFalse(ret)
+
+    @patch('mozilla_django_oidc.auth.import_from_settings')
+    def test_returns_true_if_email_in_claims(self, _):
+        ret = OIDCAuthenticationBackend().verify_claims({'email': 'bonobo@banana.nl'})
+        self.assertTrue(ret)
+
+
 def dotted_username_algo_callback(email):
     return 'dotted_username_algo'


### PR DESCRIPTION
Previously it could occur that during authentication a user would try to be created without the email claim. However the create_user function would not allow for this, returning `None`. On the surface everything seems to work fine, but no user would actually be created with no debug or warning messages to speak of. Instead of always returning `True` for `verify_claims` it would therefor make more sense if this function actually checked if the email is present before trying to create the user.

If this would break existing functionality perhaps some explicit warning message should be logged when the `create_user` function would not create the user and return `None`. To prevent hours of debugging for people :) 

Haven't updated the `HISTORY.rst` file since I wasn't sure how you guys wanted to have the changes present (and versioning etc). And I saw you guys were the more recent comitters.

Let me know if any changes need to be made to the PR, or if I should go for the logging alternative.