### PR TITLE
Verify email is in claims before creating user

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -75,17 +75,12 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def verify_claims(self, claims):
         """Verify the provided claims to decide if authentication should be allowed."""
-        return True
+        return 'email' in claims
 
     def create_user(self, claims):
         """Return object for a newly created user account."""
-
         email = claims.get('email')
-        if not email:
-            return None
-
         username = self.get_username(claims)
-
         return self.UserModel.objects.create_user(username, email)
 
     def get_username(self, claims):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1081,5 +1081,17 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         self.assertEqual(ctx.exception.args[0], 'Could not find a valid JWKS.')
 
 
+class TestVerifyClaim(TestCase):
+    @patch('mozilla_django_oidc.auth.import_from_settings')
+    def test_returns_false_if_email_not_in_claims(self, _):
+        ret = OIDCAuthenticationBackend().verify_claims({})
+        self.assertFalse(ret)
+
+    @patch('mozilla_django_oidc.auth.import_from_settings')
+    def test_returns_true_if_email_in_claims(self, _):
+        ret = OIDCAuthenticationBackend().verify_claims({'email': 'email@example.com'})
+        self.assertTrue(ret)
+
+
 def dotted_username_algo_callback(email):
     return 'dotted_username_algo'


### PR DESCRIPTION
Previously it could occur that during authentication a user would try to be created without the email claim. However the create_user function would now allow for this, returning `None`. However on the surface everything seems to work fine, with no debug or warning messages to speak of. Instead of always returning `True` for `verify_claims` it would therefor make more sense if this function actually checked if the email is present before trying to create the user.

If this would break existing functionality perhaps some explicit warning message should be logged when the `create_user` function would not create the user and return `None` to prevent hours of debugging for people :)