### PR TITLE
Automatic client configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ docs/source
 # e2e tests log
 integration_tests/ghostdriver.log
 integration_tests/geckodriver.log
+
+# Python virtual environment
+venv/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -265,6 +265,46 @@ Then you'd use the Python dotted path to that class in the
 ``mozilla_django_oidc.auth.OIDCAuthenticationBackend``.
 
 
+Automatically configuring OpenID endpoints using metadata URL
+-------------------------------------------------------------
+
+As part of the OpenID standard, we can get a provider's configuration by concatenating the string
+``/.well-known/openid-configuration`` to their location. For example, if you hit the URL
+``https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration`` on your browser
+you can see the following JSON by Microsoft:
+
+.. code-block:: python
+
+   {
+   "authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+   "token_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/token",
+   "token_endpoint_auth_methods_supported":...,
+   "jwks_uri":"https://login.microsoftonline.com/common/discovery/v2.0/keys",
+   "response_modes_supported":...,
+   ...
+
+Many details are omitted here for brevity, but as you can see that information such as
+``authorization_endpoint`` is available in this JSON.
+
+In mozilla-django-oidc you can use this feature by adding ``OIDC_REQ_METADATA`` to ``True`` and
+``OIDC_OP_METADATA_ENDPOINT`` to ``<provider location>/.well-known/openid-configuration`` in
+``settings.py`` . By default, metadata is cached using Django's
+:py:class:`django.core.cache.backends.locmem.LocMemCache` and can be configured. For example if
+you want to use file based cache add the following in your ``settings.py``.
+
+.. code-block:: python
+
+  CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '...',
+    }
+}
+
+Read more about caching in Django at ``https://docs.djangoproject.com/en/2.2/topics/cache/``.
+If you want to use cache name other than ``default`` then configure it using ``OIDC_REQ_METADATA_CACHE``.
+
+
 Creating Django users
 ---------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -224,3 +224,25 @@ of ``mozilla-django-oidc``.
    :default: False
 
    Use HTTP Basic Authentication instead of sending the client secret in token request POST body.
+
+.. py:attribute:: OIDC_OP_METADATA_ENDPOINT
+
+   :default: No default
+
+   URL of your OpenID Connect provider metadata endpoint. It will be used to configure other endpoints if  ``OIDC_REQ_METADATA`` option is set to ``True``.
+
+.. py:attribute:: OIDC_REQ_METADATA
+
+   :default: ``False``
+
+   Use OpenID Connect provider metadata endpoint to configure other endpoints.
+
+.. py:attribute:: OIDC_REQ_METADATA_CACHE
+
+   :default: ``default``
+
+   Django cache for caching metadata. By default Django's ``LocMemCache`` is used.
+
+   .. seealso::
+
+      https://docs.djangoproject.com/en/2.2/topics/cache/#local-memory-caching

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -53,8 +53,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def __init__(self, *args, **kwargs):
         """Initialize settings."""
-        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
-        # metadata endpoint of the provider.
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints
+        # are fetched from the metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:
@@ -74,8 +74,8 @@ class OIDCAuthenticationBackend(ModelBackend):
         self.OIDC_RP_SIGN_ALGO = self.get_settings('OIDC_RP_SIGN_ALGO', 'HS256')
         self.OIDC_RP_IDP_SIGN_KEY = self.get_settings('OIDC_RP_IDP_SIGN_KEY', None)
 
-        if (self.OIDC_RP_SIGN_ALGO.startswith('RS') and
-            (self.OIDC_RP_IDP_SIGN_KEY is None and self.OIDC_OP_JWKS_ENDPOINT is None)):
+        if (self.OIDC_RP_SIGN_ALGO.startswith('RS')
+                and (self.OIDC_RP_IDP_SIGN_KEY is None and self.OIDC_OP_JWKS_ENDPOINT is None)):
             msg = '{} alg requires OIDC_RP_IDP_SIGN_KEY or OIDC_OP_JWKS_ENDPOINT to be configured.'
             raise ImproperlyConfigured(msg.format(self.OIDC_RP_SIGN_ALGO))
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -62,8 +62,8 @@ class OIDCAuthenticationBackend(ModelBackend):
                 self.OIDC_OP_USER_ENDPOINT = op_metadata[OPMetadataKey.USER_INFO_ENDPOINT.value]
                 self.OIDC_OP_JWKS_ENDPOINT = op_metadata[OPMetadataKey.JWKS_ENDPOINT.value]
 
-            except KeyError as e:
-                raise SuspiciousOperation("Metadata json is not in standard format") from e
+            except KeyError:
+                raise SuspiciousOperation("Metadata json is not in standard format")
         else:
             self.OIDC_OP_TOKEN_ENDPOINT = self.get_settings('OIDC_OP_TOKEN_ENDPOINT')
             self.OIDC_OP_USER_ENDPOINT = self.get_settings('OIDC_OP_USER_ENDPOINT')

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -53,6 +53,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def __init__(self, *args, **kwargs):
         """Initialize settings."""
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
+        # metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -22,7 +22,8 @@ from josepy.b64 import b64decode
 from josepy.jwk import JWK
 from josepy.jws import JWS, Header
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings, get_from_op_metadata, is_obtainable_from_op_metadata
+from mozilla_django_oidc.utils import absolutify, import_from_settings, get_from_op_metadata, \
+    is_obtainable_from_op_metadata
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,8 +60,8 @@ class OIDCAuthenticationBackend(ModelBackend):
         self.OIDC_RP_SIGN_ALGO = self.get_settings('OIDC_RP_SIGN_ALGO', 'HS256')
         self.OIDC_RP_IDP_SIGN_KEY = self.get_settings('OIDC_RP_IDP_SIGN_KEY', None)
 
-        if (self.OIDC_RP_SIGN_ALGO.startswith('RS')
-            and (self.OIDC_RP_IDP_SIGN_KEY is None and self.OIDC_OP_JWKS_ENDPOINT is None)):
+        if (self.OIDC_RP_SIGN_ALGO.startswith('RS') and
+                (self.OIDC_RP_IDP_SIGN_KEY is None and self.OIDC_OP_JWKS_ENDPOINT is None)):
             msg = '{} alg requires OIDC_RP_IDP_SIGN_KEY or OIDC_OP_JWKS_ENDPOINT to be configured.'
             raise ImproperlyConfigured(msg.format(self.OIDC_RP_SIGN_ALGO))
 
@@ -68,8 +69,10 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     @staticmethod
     def get_settings(attr, *args):
-        # If the requested setting can be extracted from the OpenID provider's metadata and the use of it is allowed.
-        if is_obtainable_from_op_metadata(attr) and import_from_settings("OIDC_REQ_METADATA", False):
+        # If the requested setting can be extracted from the OpenID provider's metadata
+        # and the use of it is allowed.
+        if is_obtainable_from_op_metadata(attr) and \
+                import_from_settings("OIDC_REQ_METADATA", False):
             return get_from_op_metadata(attr)
 
         return import_from_settings(attr, *args)

--- a/mozilla_django_oidc/constants.py
+++ b/mozilla_django_oidc/constants.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OPMetadataKey(Enum):
+    """Keys found in openid provider's metadata json"""
+
+    AUTHORIZATION_ENDPOINT = 'authorization_endpoint'
+    TOKEN_ENDPOINT = 'token_endpoint'
+    USER_INFO_ENDPOINT = 'userinfo_endpoint'
+    JWKS_ENDPOINT = 'jwks_uri'

--- a/mozilla_django_oidc/constants.py
+++ b/mozilla_django_oidc/constants.py
@@ -8,3 +8,8 @@ class OPMetadataKey(Enum):
     TOKEN_ENDPOINT = 'token_endpoint'
     USER_INFO_ENDPOINT = 'userinfo_endpoint'
     JWKS_ENDPOINT = 'jwks_uri'
+
+
+class OIDCCacheKey(Enum):
+    """Keys for cache used in OIDC."""
+    OP_METADATA = 'op_metadata'

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -40,8 +40,10 @@ class SessionRefresh(MiddlewareMixin):
 
     @staticmethod
     def get_settings(attr, *args):
-        # If the requested setting can be extracted from the OpenID provider's metadata and the use of it is allowed.
-        if is_obtainable_from_op_metadata(attr) and import_from_settings("OIDC_REQ_METADATA", False):
+        # If the requested setting can be extracted from the OpenID provider's metadata
+        # and the use of it is allowed.
+        if is_obtainable_from_op_metadata(attr) and \
+                import_from_settings("OIDC_REQ_METADATA", False):
             return get_from_op_metadata(attr)
 
         return import_from_settings(attr, *args)

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -105,6 +105,8 @@ class SessionRefresh(MiddlewareMixin):
         LOGGER.debug('id token has expired')
         # The id_token has expired, so we have to re-authenticate silently.
 
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
+        # metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -105,8 +105,8 @@ class SessionRefresh(MiddlewareMixin):
         LOGGER.debug('id token has expired')
         # The id_token has expired, so we have to re-authenticate silently.
 
-        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
-        # metadata endpoint of the provider.
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints
+        # are fetched from the metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -112,8 +112,8 @@ class SessionRefresh(MiddlewareMixin):
             try:
                 auth_url = op_metadata[OPMetadataKey.AUTHORIZATION_ENDPOINT.value]
 
-            except KeyError as e:
-                raise SuspiciousOperation("Metadata json is not in standard format") from e
+            except KeyError:
+                raise SuspiciousOperation("Metadata json is not in standard format")
         else:
             auth_url = self.get_settings('OIDC_OP_AUTHORIZATION_ENDPOINT')
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -58,6 +58,7 @@ def is_authenticated(user):
 
 
 def get_op_metadata(op_metadata_endpoint):
+    """Return metadata from the metadata endpoint of the openid provider"""
     op_metadata = requests.get(
         url=op_metadata_endpoint,
         verify=import_from_settings('OIDC_VERIFY_SSL', True)

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -1,9 +1,10 @@
+import requests
+
 try:
     from urllib.request import parse_http_list, parse_keqv_list
 except ImportError:
     # python < 3
     from urllib2 import parse_http_list, parse_keqv_list
-
 from django import VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -54,3 +55,12 @@ def is_authenticated(user):
     if _less_than_django_1_10:
         return user.is_authenticated()
     return user.is_authenticated
+
+
+def get_op_metadata(op_metadata_endpoint):
+    op_metadata = requests.get(
+        url=op_metadata_endpoint,
+        verify=import_from_settings('OIDC_VERIFY_SSL', True)
+    )
+    op_metadata.raise_for_status()
+    return op_metadata.json()

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -137,12 +137,13 @@ class OIDCAuthenticationRequestView(View):
     def __init__(self, *args, **kwargs):
         super(OIDCAuthenticationRequestView, self).__init__(*args, **kwargs)
 
-        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
-        # metadata endpoint of the provider.
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints
+        # are fetched from the metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:
-                self.OIDC_OP_AUTH_ENDPOINT = op_metadata[OPMetadataKey.AUTHORIZATION_ENDPOINT.value]
+                self.OIDC_OP_AUTH_ENDPOINT \
+                    = op_metadata[OPMetadataKey.AUTHORIZATION_ENDPOINT.value]
 
             except KeyError as e:
                 raise SuspiciousOperation("Metadata json is not in standard format") from e

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -145,8 +145,8 @@ class OIDCAuthenticationRequestView(View):
                 self.OIDC_OP_AUTH_ENDPOINT \
                     = op_metadata[OPMetadataKey.AUTHORIZATION_ENDPOINT.value]
 
-            except KeyError as e:
-                raise SuspiciousOperation("Metadata json is not in standard format") from e
+            except KeyError:
+                raise SuspiciousOperation("Metadata json is not in standard format")
 
         else:
             self.OIDC_OP_AUTH_ENDPOINT = self.get_settings('OIDC_OP_AUTHORIZATION_ENDPOINT')

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -137,6 +137,8 @@ class OIDCAuthenticationRequestView(View):
     def __init__(self, *args, **kwargs):
         super(OIDCAuthenticationRequestView, self).__init__(*args, **kwargs)
 
+        # If 'OIDC_REQUEST_METADATA' is set to True in settings then relevant openid endpoints are fetched from the
+        # metadata endpoint of the provider.
         if self.get_settings("OIDC_REQUEST_METADATA", False):
             op_metadata = get_op_metadata(self.get_settings("OIDC_OP_METADATA_ENDPOINT"))
             try:

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -140,8 +140,10 @@ class OIDCAuthenticationRequestView(View):
 
     @staticmethod
     def get_settings(attr, *args):
-        # If the requested setting can be extracted from the OpenID provider's metadata and the use of it is allowed.
-        if is_obtainable_from_op_metadata(attr) and import_from_settings("OIDC_REQ_METADATA", False):
+        # If the requested setting can be extracted from the OpenID provider's metadata
+        # and the use of it is allowed.
+        if is_obtainable_from_op_metadata(attr) and \
+                import_from_settings("OIDC_REQ_METADATA", False):
             return get_from_op_metadata(attr)
 
         return import_from_settings(attr, *args)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -810,12 +810,12 @@ class OIDCAuthenticationBackendTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @override_settings(OIDC_RP_CLIENT_SECRET='client_secret')
     @patch('mozilla_django_oidc.auth.get_op_metadata')
-    def test_backend_initialization_with_metadata_endpoint(self, get_op_metadata_patch):
+    def test_backend_init_with_metadata_endpoint(self, get_op_metadata_patch):
         """Test that backend is initialized properly from metadata endpoint"""
-        get_op_metadata_patch.return_value = {OPMetadataKey.TOKEN_ENDPOINT.value: 'token_endpoint',
-                                              OPMetadataKey.USER_INFO_ENDPOINT.value: 'user_info_endpoint',
-                                              OPMetadataKey.JWKS_ENDPOINT.value: 'jwks_endpoint'
-                                              }
+        get_op_metadata_patch.return_value \
+            = {OPMetadataKey.TOKEN_ENDPOINT.value: 'token_endpoint',
+               OPMetadataKey.USER_INFO_ENDPOINT.value: 'user_info_endpoint',
+               OPMetadataKey.JWKS_ENDPOINT.value: 'jwks_endpoint'}
         test_backend = OIDCAuthenticationBackend()
 
         self.assertEqual(test_backend.OIDC_OP_TOKEN_ENDPOINT, 'token_endpoint')
@@ -828,7 +828,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @override_settings(OIDC_RP_CLIENT_SECRET='client_secret')
     @patch('mozilla_django_oidc.auth.get_op_metadata')
-    def test_backend_initialization_with_metadata_endpoint_faulty_deta(self, get_op_metadata_patch):
+    def test_backend_init_with_metadata_endpoint_faulty_deta(self, get_op_metadata_patch):
         """Test that exception is thrown if metadata is not standard"""
         get_op_metadata_patch.return_value = dict()  # empty metadata dictionary
 
@@ -1116,20 +1116,23 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
 class TestVerifyClaim(TestCase):
     @patch('mozilla_django_oidc.auth.import_from_settings')
     def test_returns_false_if_email_not_in_claims(self, patch_settings):
-        patch_settings.side_effect = lambda setting, *args: 'openid email' if setting == 'OIDC_RP_SCOPES' else ''
+        patch_settings.side_effect = \
+            lambda setting, *args: 'openid email' if setting == 'OIDC_RP_SCOPES' else ''
         ret = OIDCAuthenticationBackend().verify_claims({})
         self.assertFalse(ret)
 
     @patch('mozilla_django_oidc.auth.import_from_settings')
     def test_returns_true_if_email_in_claims(self, patch_settings):
-        patch_settings.side_effect = lambda setting, *args: 'openid email' if setting == 'OIDC_RP_SCOPES' else ''
+        patch_settings.side_effect = \
+            lambda setting, *args: 'openid email' if setting == 'OIDC_RP_SCOPES' else ''
         ret = OIDCAuthenticationBackend().verify_claims({'email': 'email@example.com'})
         self.assertTrue(ret)
 
     @patch('mozilla_django_oidc.auth.import_from_settings')
     @patch('mozilla_django_oidc.auth.LOGGER')
     def test_returns_true_custom_claims(self, patch_logger, patch_settings):
-        patch_settings.side_effect = lambda setting, *args: 'foo bar' if setting == 'OIDC_RP_SCOPES' else ''
+        patch_settings.side_effect = \
+            lambda setting, *args: 'foo bar' if setting == 'OIDC_RP_SCOPES' else ''
         ret = OIDCAuthenticationBackend().verify_claims({})
         self.assertTrue(ret)
         msg = ('Custom OIDC_RP_SCOPES defined. '

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,22 +1,20 @@
 import json
-from mock import Mock, call, patch
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac
-from josepy.b64 import b64encode
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils import six
 from django.utils.encoding import force_bytes, smart_text
+from josepy.b64 import b64encode
+from mock import Mock, call, patch
 
 from mozilla_django_oidc.auth import (
     default_username_algo,
     OIDCAuthenticationBackend,
 )
-from mozilla_django_oidc.constants import OPMetadataKey
 
 User = get_user_model()
 
@@ -805,36 +803,28 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
         self.assertEqual(User.objects.get().first_name, 'a_username')
 
-    @override_settings(OIDC_REQUEST_METADATA=True)
+    @override_settings(OIDC_REQ_METADATA=True)
     @override_settings(OIDC_OP_METADATA_ENDPOINT='metadata_endpoint')
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @override_settings(OIDC_RP_CLIENT_SECRET='client_secret')
-    @patch('mozilla_django_oidc.auth.get_op_metadata')
-    def test_backend_init_with_metadata_endpoint(self, get_op_metadata_patch):
+    @patch('mozilla_django_oidc.auth.get_from_op_metadata')
+    def test_backend_init_with_metadata_endpoint(self, get_from_op_metadata_patch):
         """Test that backend is initialized properly from metadata endpoint"""
-        get_op_metadata_patch.return_value \
-            = {OPMetadataKey.TOKEN_ENDPOINT.value: 'token_endpoint',
-               OPMetadataKey.USER_INFO_ENDPOINT.value: 'user_info_endpoint',
-               OPMetadataKey.JWKS_ENDPOINT.value: 'jwks_endpoint'}
+
+        def side_effect(attr):
+            if attr == 'OIDC_OP_TOKEN_ENDPOINT':
+                return 'token_endpoint'
+            elif attr == 'OIDC_OP_USER_ENDPOINT':
+                return 'user_info_endpoint'
+            elif attr == 'OIDC_OP_JWKS_ENDPOINT':
+                return 'jwks_endpoint'
+
+        get_from_op_metadata_patch.side_effect = side_effect
         test_backend = OIDCAuthenticationBackend()
 
         self.assertEqual(test_backend.OIDC_OP_TOKEN_ENDPOINT, 'token_endpoint')
         self.assertEqual(test_backend.OIDC_OP_USER_ENDPOINT, 'user_info_endpoint')
         self.assertEqual(test_backend.OIDC_OP_JWKS_ENDPOINT, 'jwks_endpoint')
-        get_op_metadata_patch.assert_called_once_with('metadata_endpoint')
-
-    @override_settings(OIDC_REQUEST_METADATA=True)
-    @override_settings(OIDC_OP_METADATA_ENDPOINT='metadata_endpoint')
-    @override_settings(OIDC_RP_CLIENT_ID='example_id')
-    @override_settings(OIDC_RP_CLIENT_SECRET='client_secret')
-    @patch('mozilla_django_oidc.auth.get_op_metadata')
-    def test_backend_init_with_metadata_endpoint_faulty_deta(self, get_op_metadata_patch):
-        """Test that exception is thrown if metadata is not standard"""
-        get_op_metadata_patch.return_value = dict()  # empty metadata dictionary
-
-        with self.assertRaises(SuspiciousOperation) as context:
-            OIDCAuthenticationBackend()
-        self.assertEqual(str(context.exception), "Metadata json is not in standard format")
 
 
 class OIDCAuthenticationBackendRS256WithKeyTestCase(TestCase):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -152,9 +152,13 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='foo')
     @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
     @patch('mozilla_django_oidc.middleware.get_op_metadata')
-    def test_auth_endpoint_retrieved_correctly_from_metadata_on_expiration(self, get_op_metadata_patch):
-        """Test that on token refresh if metadata endpoint is given then auth endpoint is retrieved correctly"""
-        get_op_metadata_patch.return_value = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
+    def test_auth_endpoint_from_metadata_on_expiration(self, get_op_metadata_patch):
+        """
+        Test that on token refresh if metadata endpoint is given then auth endpoint
+        is retrieved correctly
+        """
+        get_op_metadata_patch.return_value\
+            = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
         request = self.factory.get('/foo')
         request.user = self.user
         request.session = {}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,8 @@
 import json
 import time
 
+from mozilla_django_oidc.constants import OPMetadataKey
+
 try:
     from urllib.parse import parse_qs
 except ImportError:
@@ -23,9 +25,7 @@ from django.test.client import ClientHandler
 from mozilla_django_oidc.middleware import SessionRefresh
 from mozilla_django_oidc.urls import urlpatterns as orig_urlpatterns
 
-
 User = get_user_model()
-
 
 DJANGO_VERSION = tuple(django.VERSION[0:2])
 
@@ -147,6 +147,25 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
         }
         self.assertEquals(expected_query, parse_qs(qs))
 
+    @override_settings(OIDC_REQUEST_METADATA=True)
+    @override_settings(OIDC_OP_METADATA_ENDPOINT='metadata_endpoint')
+    @override_settings(OIDC_RP_CLIENT_ID='foo')
+    @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
+    @patch('mozilla_django_oidc.middleware.get_op_metadata')
+    def test_auth_endpoint_retrieved_correctly_from_metadata_on_expiration(self, get_op_metadata_patch):
+        """Test that on token refresh if metadata endpoint is given then auth endpoint is retrieved correctly"""
+        get_op_metadata_patch.return_value = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
+        request = self.factory.get('/foo')
+        request.user = self.user
+        request.session = {}
+
+        response = self.middleware.process_request(request)
+
+        self.assertEquals(response.status_code, 302)
+        url, qs = response.url.split('?')
+        self.assertEquals(url, 'auth_endpoint')
+        get_op_metadata_patch.assert_called_once_with('metadata_endpoint')
+
 
 # This adds a "home page" we can test against.
 def fakeview(req):
@@ -170,6 +189,7 @@ def override_middleware(fun):
 
 class UserifiedClientHandler(ClientHandler):
     """Enhances ClientHandler to "work" with users properly"""
+
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
         super(UserifiedClientHandler, self).__init__(*args, **kwargs)
@@ -181,6 +201,7 @@ class UserifiedClientHandler(ClientHandler):
 
 class ClientWithUser(Client):
     """Enhances Client to "work" with users properly"""
+
     def __init__(self, enforce_csrf_checks=False, **defaults):
         # Start off with the AnonymousUser
         self.user = AnonymousUser()
@@ -217,6 +238,7 @@ class ClientWithUser(Client):
 @override_middleware
 class MiddlewareTestCase(TestCase):
     """These tests test the middleware as part of the request/response cycle"""
+
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(username='example_username', password='password')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
+from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from mock import patch, Mock
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings, get_op_metadata
+from mozilla_django_oidc.constants import OIDCCacheKey
+from mozilla_django_oidc.utils import absolutify, import_from_settings, \
+    get_op_metadata, _op_metadata_settings, \
+    extract_settings_from_op_metadata, get_from_op_metadata
 
 
 class SettingImportTestCase(TestCase):
@@ -62,3 +66,75 @@ class GetOPMetadataTestCase(TestCase):
 
         self.assertEqual(get_op_metadata('test_endpoint'), {'test_key': 'test_value'})
         requests_patch.get.assert_called_once_with(url='test_endpoint', verify=True)
+
+
+class ExtractSettingsFromOPMetadataTestCase(TestCase):
+
+    def test_extract_settings_from_op_metadata(self):
+        """
+        Testing that all the metadata settings configured in utils should result non none values
+        after metadata extraction.
+        """
+        op_metadata_sample_dict = {
+            'authorization_endpoint': 'test_auth',
+            'token_endpoint': 'test_token',
+            'userinfo_endpoint': 'test_userinfo',
+            'jwks_uri': 'test_jwks'
+        }
+        for attr in _op_metadata_settings:
+            self.assertIsNotNone(extract_settings_from_op_metadata(op_metadata_sample_dict, attr))
+
+    def test_extract_settings_from_op_metadata_faulty_metadata(self):
+        """Testing 'KeyError' is raised when metadata is faulty"""
+        op_metadata_faulty_dict = {
+            'token_endpoint': 'test_token',
+            'userinfo_endpoint': 'test_userinfo',
+            'jwks_uri': 'test_jwks'
+        }
+        with self.assertRaises(KeyError):
+            extract_settings_from_op_metadata(op_metadata_faulty_dict,
+                                              'OIDC_OP_AUTHORIZATION_ENDPOINT')
+
+    def test_extract_settings_from_op_metadata_incorrect_configuration(self):
+        """
+        Testing 'ImproperlyConfigured' is raised if we pass some setting which
+        is not configured
+        """
+        op_metadata_sample_dict = {
+            'authorization_endpoint': 'test_auth',
+            'token_endpoint': 'test_token',
+            'userinfo_endpoint': 'test_userinfo',
+            'jwks_uri': 'test_jwks'
+        }
+        with self.assertRaises(ImproperlyConfigured):
+            extract_settings_from_op_metadata(op_metadata_sample_dict, 'test')
+
+
+class GetFromOPMetadataTestCase(TestCase):
+
+    @override_settings(OIDC_OP_METADATA_ENDPOINT='test_metadata_url')
+    @patch('mozilla_django_oidc.utils.extract_settings_from_op_metadata')
+    @patch('mozilla_django_oidc.utils.get_op_metadata')
+    def test_get_from_op_metadata(self, get_op_metadata_patch,
+                                  extract_settings_from_op_metadata_patch):
+        """Testing that caching is happening properly."""
+        get_op_metadata_patch.return_value = 'test_metadata'
+        extract_settings_from_op_metadata_patch.return_value = 'test_value'
+
+        self.assertEqual(get_from_op_metadata('test_attr'), 'test_value')
+        # By default local memory cache will be used.
+        self.assertEqual(cache.get(OIDCCacheKey.OP_METADATA.value), 'test_metadata')
+
+    @override_settings(OIDC_OP_METADATA_ENDPOINT='test_metadata_url')
+    @patch('mozilla_django_oidc.utils.extract_settings_from_op_metadata')
+    @patch('mozilla_django_oidc.utils.get_op_metadata')
+    def test_get_from_op_metadata_already_cached(self, get_op_metadata_patch,
+                                                 extract_settings_from_op_metadata_patch):
+        """Testing that cached value must be used if exists."""
+        cache.set(OIDCCacheKey.OP_METADATA.value, 'test_metadata')
+        get_op_metadata_patch.side_effect = Exception("It should not be called")
+        extract_settings_from_op_metadata_patch.return_value = 'test_value'
+
+        self.assertEqual(get_from_op_metadata('test_attr'), 'test_value')
+        extract_settings_from_op_metadata_patch.\
+            assert_called_once_with('test_metadata', 'test_attr')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,5 @@
+from mozilla_django_oidc.constants import OPMetadataKey
+
 try:
     from urllib.parse import parse_qs, urlparse
 except ImportError:
@@ -10,6 +12,7 @@ import django
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+
 try:
     from django.urls import reverse
 except ImportError:
@@ -18,7 +21,6 @@ except ImportError:
 from django.test import RequestFactory, TestCase, override_settings
 
 from mozilla_django_oidc import views
-
 
 User = get_user_model()
 
@@ -499,6 +501,37 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         login_view(request)
         self.assertTrue('oidc_login_next' in request.session)
         self.assertTrue(request.session['oidc_login_next'] is None)
+
+    @override_settings(OIDC_REQUEST_METADATA=True)
+    @override_settings(OIDC_OP_METADATA_ENDPOINT='metadata_endpoint')
+    @override_settings(OIDC_RP_CLIENT_ID="client_id")
+    @patch('mozilla_django_oidc.views.get_op_metadata')
+    def test_get_with_metadata_endpoint(self, get_op_metadata_patch):
+        """Test that endpoint from metadata is extracted successfully"""
+        get_op_metadata_patch.return_value = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
+        request = self.factory.get(reverse('oidc_authentication_init'))
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+        response = login_view(request)
+        o = urlparse(response.url)
+
+        self.assertEqual(o.path, 'auth_endpoint')
+        get_op_metadata_patch.assert_called_once_with('metadata_endpoint')
+
+    @override_settings(OIDC_REQUEST_METADATA=True)
+    @override_settings(OIDC_OP_METADATA_ENDPOINT='metadata_endpoint')
+    @override_settings(OIDC_RP_CLIENT_ID="client_id")
+    @patch('mozilla_django_oidc.views.get_op_metadata')
+    def test_get_with_metadata_endpoint_invalid_format(self, get_op_metadata_patch):
+        """Test that exception is raised if metadata document is not in expected format"""
+        get_op_metadata_patch.return_value = dict()  # empty metadata dictionary
+        request = self.factory.get(reverse('oidc_authentication_init'))
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+
+        with self.assertRaises(SuspiciousOperation) as context:
+            login_view(request)
+        self.assertEqual(str(context.exception), "Metadata json is not in standard format")
 
 
 class OIDCLogoutViewTestCase(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -508,7 +508,8 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @patch('mozilla_django_oidc.views.get_op_metadata')
     def test_get_with_metadata_endpoint(self, get_op_metadata_patch):
         """Test that endpoint from metadata is extracted successfully"""
-        get_op_metadata_patch.return_value = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
+        get_op_metadata_patch.return_value \
+            = {OPMetadataKey.AUTHORIZATION_ENDPOINT.value: 'auth_endpoint'}
         request = self.factory.get(reverse('oidc_authentication_init'))
         request.session = dict()
         login_view = views.OIDCAuthenticationRequestView.as_view()


### PR DESCRIPTION
Users will now able to use metadata response for automatic configuration using metadata endpoint and turn in on and off also. I have added relevant test cases and linting. In the 'Contributing' document it was written to update documentation in History.rst and Readme.rst. But I think History.rst contains change log for a version and Readme.rst  doesn't contain any feature list. So I am not clear about where to put the documentation.