### PR TITLE
Add OIDC_EXEMPT_URL_PREFIXES setting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 -------
 
+1.2.4 (Unreleased)
+===================
+
+* Add ``OIDC_EXEMPT_URL_PREFIXES``, a list of absolute URL path prefixes which
+  are exempt from session refreshes in ``SessionMiddleware``.
+  Thanks `@jwhitlock`_
+
+.. _`@jwhitlock`: https://github.com/jwhitlock
+
 1.2.3 (2020-01-02)
 ===================
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -81,6 +81,14 @@ of ``mozilla-django-oidc``.
    mozilla-django-oidc urls are exempted from the session renewal by the
    ``SessionRefresh`` middleware.
 
+.. py:attribute:: OIDC_EXEMPT_URL_PREFIXES
+
+   :default: ``[]``
+
+   This is a list of absolute url path prefixes, such a ``['/foo/']``.
+   A request that starts with one of these prefixes is exempt from the session
+   renewal by the ``SessionRefresh`` middleware.
+
 .. py:attribute:: OIDC_CREATE_USER
 
    :default: ``True``

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -73,12 +73,14 @@ class SessionRefresh(MiddlewareMixin):
         if backend_session:
             auth_backend = import_string(backend_session)
             is_oidc_enabled = issubclass(auth_backend, OIDCAuthenticationBackend)
+        exempt_prefixes = list(self.get_settings('OIDC_EXEMPT_URL_PREFIXES', []))
 
         return (
             request.method == 'GET' and
             request.user.is_authenticated and
             is_oidc_enabled and
-            request.path not in self.exempt_urls
+            request.path not in self.exempt_urls and
+            not any(request.path.startswith(prefix) for prefix in exempt_prefixes)
         )
 
     def process_request(self, request):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -239,6 +239,37 @@ class MiddlewareTestCase(TestCase):
             [u'/authenticate/', u'/callback/', u'/foo/', u'/logout/']
         )
 
+    def test_is_refreshable_url(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URLS=['mdo_fake_view'])
+    def test_is_not_refreshable_url_exempt_view_name(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URLS=['/mdo_fake_view/'])
+    def test_is_not_refreshable_url_exempt_path(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URL_PREFIXES=['/mdo_fake_view/'])
+    def test_is_not_refreshable_url_exempt_prefix(self):
+        request = self.factory.get('/mdo_fake_view/subview')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
+
     def test_anonymous(self):
         client = ClientWithUser()
         resp = client.get('/mdo_fake_view/')


### PR DESCRIPTION
Add a setting ``OIDC_EXEMPT_URL_PREFIXES``, which works like ``OIDC_EXEMPT_URLS``, avoiding session renewal for any request path that starts with an absolute path string.

On Socorro, we suspect that JavaScript requests with an OIDC session renewal causes problems. We've exempted some of these endpoints (see https://github.com/mozilla-services/socorro/pull/4957), but others have a parameter in the URL string, like ``/signature/graph/<field>/``, which takes a field to graph. 

This would allow us to exclude these paths as well:

```
OIDC_EXEMPT_URLS = [
    'signature:signature_summary',
    'signature:signature_reports',
    ...
]
OIDC_EXEMPT_URL_PREFIXES = [
    '/signature/graph/',
    '/signature/aggregation/',
]
```

Others with similar usage may have a consistent path for JavaScript requests, such as ``/api/``, and could use this instead of listing all request paths.

Alternatively, our code could use a setting ``OIDC_EXEMPT_AJAX``, which would avoid session refresh if ``request.is_ajax()``.