### PR TITLE
Expand OIDC_EXEMPT_URLS to take prefixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,16 @@
 History
 -------
 
+1.2.3 (Unreleased)
+++++++++++++++++++
+* Expand ``OIDC_EXEMPT_URLS`` to take an absolute URL ending in ``*``,
+  to specify path prefixes which are exempt from session refreshes in
+  ``SessionMiddleware``. Thanks `@jwhitlock`_
+
+.. _`@jwhitlock`: https://github.com/jwhitlock
+
 1.2.2 (2019-04-18)
-*******************
+++++++++++++++++++
 
 * Add Mozilla code of conduct
 * Allow overriding OIDC settings per class

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -57,9 +57,9 @@ of ``mozilla-django-oidc``.
 
    :default: ``[]``
 
-   This is a list of absolute url paths or Django view names. This plus the
-   mozilla-django-oidc urls are exempted from the session renewal by the
-   ``SessionRefresh`` middleware.
+   This is a list of absolute url paths, absolute url path prefixes ending in a
+   ``*``, or Django view names. These plus the mozilla-django-oidc urls are
+   exempted from the session renewal by the ``SessionRefresh`` middleware.
 
 .. py:attribute:: OIDC_CREATE_USER
 


### PR DESCRIPTION
When an absolute URL has a trailing ``*``, such as ``'/api/*'``, treat it as a prefix for URLs, such as ```/api/posts/3```, that should be exempt from session renewal.

This was suggested by @willkg as an alternate approach to PR #310.