### PR TITLE
Add OIDCClient for django tests

### DIFF
--- a/mozilla_django_oidc/test.py
+++ b/mozilla_django_oidc/test.py
@@ -1,0 +1,11 @@
+from django.test.client import Client
+
+
+class OIDCClient(Client):
+    oidc_id_token = 'some_oidc_token'
+
+    def __init__(self, enforce_csrf_checks=False, **defaults):
+        super(OIDCClient, self).__init__(enforce_csrf_checks=enforce_csrf_checks, **defaults)
+        session = self.session
+        session['oidc_id_token'] = self.oidc_id_token
+        session.save()

--- a/tests/test_oidc_client.py
+++ b/tests/test_oidc_client.py
@@ -1,10 +1,11 @@
+from unittest import TestCase
+
 from django.test.client import Client
-from django.test.testcases import SimpleTestCase
 
 from mozilla_django_oidc.test import OIDCClient
 
 
-class TestOIDCClient(SimpleTestCase):
+class TestOIDCClient(TestCase):
     def test_inherits_from_django_test_client(self):
         self.assertIsInstance(OIDCClient(), Client)
 

--- a/tests/test_oidc_client.py
+++ b/tests/test_oidc_client.py
@@ -1,0 +1,22 @@
+from django.test.client import Client
+from django.test.testcases import SimpleTestCase
+
+from mozilla_django_oidc.test import OIDCClient
+
+
+class TestOIDCClient(SimpleTestCase):
+    def test_inherits_from_django_test_client(self):
+        self.assertIsInstance(OIDCClient(), Client)
+
+    def test_oidc_id_token_is_set_to_some_token_by_default(self):
+        self.assertEqual(OIDCClient.oidc_id_token, 'some_oidc_token')
+
+    def test_sets_oidc_id_token_for_session(self):
+        self.assertEqual(OIDCClient().session['oidc_id_token'], 'some_oidc_token')
+
+    def test_sets_specified_id_token_for_session(self):
+        class StubOIDCClient(OIDCClient):
+            oidc_id_token = 'some_other_oidc_token'
+
+        client = StubOIDCClient()
+        self.assertEqual(client.session['oidc_id_token'], 'some_other_oidc_token')


### PR DESCRIPTION
Add an OIDCClient for django tests. This can be useful when you need to use the `oidc_id_token` in your views. The default Django test client does not provide this. By making use of this new client your requests will contain a `oidc_id_token` key with a random value (which you can specify). Because there is no easy way to do this yourself for the Django test client (you can either fix it by writing a custom client or by using a `RequestFactory`, both are not very ideal) I thought it would be useful to provide a default client that comes with the mozilla library.