### PR TITLE
Django compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,14 @@ jobs:
           - TEST_OIDC_ALGO=hs
           - DJANGO_VERSION=Django>=2.1.0,<2.2
     <<: *common_steps
+  e2e_test_py3_hs_django220:
+    docker:
+      - image: mozillaparsys/oidc_e2e_setup:py3
+        name: testoidcsetup
+        environment:
+          - TEST_OIDC_ALGO=hs
+          - DJANGO_VERSION=Django>=2.2.0,<3.0
+    <<: *common_steps
 
 workflows:
   version: 2
@@ -145,3 +153,6 @@ workflows:
       - e2e_test_py3_hs_django210:
           requires:
             - build_lib
+      - e2e_test_py3_hs_django220:
+        requires:
+          - build_lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,14 @@ jobs:
           - TEST_OIDC_ALGO=hs
           - DJANGO_VERSION=Django>=2.2.0,<3.0
     <<: *common_steps
+  e2e_test_py3_hs_django300:
+    docker:
+      - image: mozillaparsys/oidc_e2e_setup:py3
+        name: testoidcsetup
+        environment:
+          - TEST_OIDC_ALGO=hs
+          - DJANGO_VERSION=Django>=3.0.0,<3.1
+    <<: *common_steps
 
 workflows:
   version: 2
@@ -154,5 +162,8 @@ workflows:
           requires:
             - build_lib
       - e2e_test_py3_hs_django220:
+        requires:
+          - build_lib
+      - e2e_test_py3_hs_django300:
         requires:
           - build_lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-
-# Workaround for python 3.7
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install codecov tox-travis

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check
+3. The pull request should work for Python 2.7, and 3.4+, and for PyPy. Check
    `<https://travis-ci.org/mozilla/mozilla-django-oidc/pull_requests>`_
    and make sure that the tests pass for all supported Python versions.
 
@@ -120,7 +120,7 @@ We use tox to run tests::
 
 To run a specific environment, use the ``-e`` argument::
 
-    $ tox -e py27-django18
+    $ tox -e py27-django111
 
 
 You can also run the tests in a virtual environment without tox::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -288,15 +288,15 @@ dotted path to the function you want to use.
 The function takes in an email address as a text (Python 2 unicode or Python 3
 string) and returns a text (Python 2 unicode or Python 3 string).
 
-Here's an example function for Python 3 and Django 1.11 that doesn't convert
-the email address at all:
+Here's an example function for Python 3 that doesn't convert the email address
+at all:
 
 .. code-block:: python
 
    import unicodedata
 
    def generate_username(email):
-       # Using Python 3 and Django 1.11, usernames can contain alphanumeric
+       # Using Python 3 and Django 1.11+, usernames can contain alphanumeric
        # (ascii and unicode), _, @, +, . and - characters. So we normalize
        # it and slice at 150 characters.
        return unicodedata.normalize('NFKC', email)[:150]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -124,7 +124,7 @@ documentation for the appropriate values.
 
    You can find more info about `cookie-based sessions`_ in Django's documentation.
 
-.. _cookie-based sessions: https://docs.djangoproject.com/en/1.11/topics/http/sessions/#using-cookie-based-sessions
+.. _cookie-based sessions: https://docs.djangoproject.com/en/stable/topics/http/sessions/#using-cookie-based-sessions
 
 
 These values relate to your site.
@@ -304,11 +304,8 @@ the email address at all:
 
 .. seealso::
 
-   Django 1.11 username:
-       https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.models.User.username
-
-   Django 2.0 username:
-       https://docs.djangoproject.com/en/2.0/ref/contrib/auth/#django.contrib.auth.models.User.username
+   Django username:
+       https://docs.djangoproject.com/en/stable/ref/contrib/auth/#django.contrib.auth.models.User.username
 
 
 Changing how Django users are created

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -304,9 +304,6 @@ the email address at all:
 
 .. seealso::
 
-   Django 1.8 username:
-       https://docs.djangoproject.com/en/1.8/ref/contrib/auth/#django.contrib.auth.models.User.username
-
    Django 1.11 username:
        https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.models.User.username
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -179,7 +179,7 @@ of ``mozilla-django-oidc``.
 
 .. py:attribute:: LOGOUT_REDIRECT_URL
 
-   :default: ``/`` (Django <= 1.9) ``None`` (Django 1.10+)
+   :default: ``None``
 
    After the logout view has logged the user out, it redirects to this url path.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -169,7 +169,7 @@ of ``mozilla-django-oidc``.
 
    .. seealso::
 
-      https://docs.djangoproject.com/en/1.11/ref/settings/#login-redirect-url
+      https://docs.djangoproject.com/en/stable/ref/settings/#login-redirect-url
 
 .. py:attribute:: LOGIN_REDIRECT_URL_FAILURE
 
@@ -185,7 +185,7 @@ of ``mozilla-django-oidc``.
 
    .. seealso::
 
-      https://docs.djangoproject.com/en/1.11/ref/settings/#logout-redirect-url
+      https://docs.djangoproject.com/en/stable/ref/settings/#logout-redirect-url
 
 .. py:attribute:: OIDC_OP_LOGOUT_URL_METHOD
 
@@ -206,7 +206,7 @@ of ``mozilla-django-oidc``.
 
    .. seealso::
 
-      https://docs.djangoproject.com/en/2.0/topics/http/urls/#url-namespaces
+      https://docs.djangoproject.com/en/stable/topics/http/urls/#url-namespaces
 
 .. py:attribute:: OIDC_ALLOW_UNSECURED_JWT
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -8,11 +8,7 @@ from requests.auth import HTTPBasicAuth
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import SuspiciousOperation, ImproperlyConfigured
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 2.0.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.encoding import force_bytes, smart_text, smart_bytes
 from django.utils.module_loading import import_string
 from django.utils import six

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import requests
+import six
 from requests.auth import HTTPBasicAuth
 
 from django.contrib.auth import get_user_model
@@ -11,7 +12,6 @@ from django.core.exceptions import SuspiciousOperation, ImproperlyConfigured
 from django.urls import reverse
 from django.utils.encoding import force_bytes, smart_text, smart_bytes
 from django.utils.module_loading import import_string
-from django.utils import six
 
 from josepy.b64 import b64decode
 from josepy.jwk import JWK

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -6,11 +6,7 @@ except ImportError:
     # Python < 3
     from urllib import urlencode
 
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 2.0.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import BACKEND_SESSION_KEY
 from django.http import HttpResponseRedirect, JsonResponse
 from django.utils.crypto import get_random_string

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -15,11 +15,7 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
-from mozilla_django_oidc.utils import (
-    absolutify,
-    import_from_settings,
-    is_authenticated
-)
+from mozilla_django_oidc.utils import absolutify, import_from_settings
 
 
 LOGGER = logging.getLogger(__name__)
@@ -77,7 +73,7 @@ class SessionRefresh(MiddlewareMixin):
 
         return (
             request.method == 'GET' and
-            is_authenticated(request.user) and
+            request.user.is_authenticated and
             is_oidc_enabled and
             request.path not in self.exempt_urls
         )

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -4,7 +4,6 @@ except ImportError:
     # python < 3
     from urllib2 import parse_http_list, parse_keqv_list
 
-from django import VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -36,21 +35,3 @@ def import_from_settings(attr, *args):
 def absolutify(request, path):
     """Return the absolute URL of a path."""
     return request.build_absolute_uri(path)
-
-
-# Computed once, reused in every request
-_less_than_django_1_10 = VERSION < (1, 10)
-
-
-def is_authenticated(user):
-    """return True if the user is authenticated.
-
-    This is necessary because in Django 1.10 the `user.is_authenticated`
-    stopped being a method and is now a property.
-    Actually `user.is_authenticated()` actually works, thanks to a backwards
-    compat trick in Django. But in Django 2.0 it will cease to work
-    as a callable method.
-    """
-    if _less_than_django_1_10:
-        return user.is_authenticated()
-    return user.is_authenticated

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -6,11 +6,7 @@ except ImportError:
     from urllib import urlencode
 
 from django.core.exceptions import SuspiciousOperation
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 2.0.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib import auth
 from django.http import HttpResponseRedirect
 from django.utils.crypto import get_random_string

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -14,11 +14,7 @@ from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from django.views.generic import View
 
-from mozilla_django_oidc.utils import (
-    absolutify,
-    import_from_settings,
-    is_authenticated
-)
+from mozilla_django_oidc.utils import absolutify, import_from_settings
 
 
 class OIDCAuthenticationCallbackView(View):
@@ -68,9 +64,9 @@ class OIDCAuthenticationCallbackView(View):
             # otherwise the refresh middleware will force the user to
             # redirect to authorize again if the session refresh has
             # expired.
-            if is_authenticated(request.user):
+            if request.user.is_authenticated:
                 auth.logout(request)
-            assert not is_authenticated(request.user)
+            assert not request.user.is_authenticated
         elif 'code' in request.GET and 'state' in request.GET:
             kwargs = {
                 'request': request,
@@ -192,7 +188,7 @@ class OIDCLogoutView(View):
         """Log out the user."""
         logout_url = self.redirect_url
 
-        if is_authenticated(request.user):
+        if request.user.is_authenticated:
             # Check if a method exists to build the URL to log out the user
             # from the OP.
             logout_from_op = self.get_settings('OIDC_OP_LOGOUT_URL_METHOD', '')

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ install_requirements = [
     'Django >= 1.11',
     'josepy',
     'requests',
-    'cryptography'
+    'cryptography',
+    'six',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Intended Audience :: Developers',
         'Operating System :: MacOS',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Intended Audience :: Developers',
         'Operating System :: MacOS',
@@ -72,5 +73,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tests/namespaced_urls.py
+++ b/tests/namespaced_urls.py
@@ -1,8 +1,3 @@
-import django
 from django.conf.urls import url, include
 
-
-if django.VERSION < (1, 8, 99):
-    urlpatterns = [url(r'^namespace/', include('mozilla_django_oidc.urls', namespace='namespace'))]
-else:
-    urlpatterns = [url(r'^namespace/', include(('mozilla_django_oidc.urls', 'namespace')))]
+urlpatterns = [url(r'^namespace/', include(('mozilla_django_oidc.urls', 'namespace')))]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,3 @@
-import django
-
-
 SECRET_KEY = 'can you keep a secret?'
 
 DEBUG = True
@@ -32,9 +29,6 @@ INSTALLED_APPS = [
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
-if tuple(django.VERSION[0:2]) >= (1, 10):
-    MIDDLEWARE = []
-else:
-    MIDDLEWARE_CLASSES = []
+MIDDLEWARE = []
 
 OIDC_USERNAME_ALGO = None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import json
+import six
 from mock import Mock, call, patch
 
 from cryptography.hazmat.backends import default_backend
@@ -9,7 +10,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.test import RequestFactory, TestCase, override_settings
-from django.utils import six
 from django.utils.encoding import force_bytes, smart_text
 
 from mozilla_django_oidc.auth import (

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -434,8 +434,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         self.backend.authenticate(request=auth_request)
         self.assertEqual(User.objects.all().count(), 1)
         user = User.objects.all()[0]
-        self.assertEquals(user.email, 'email@example.com')
-        self.assertEquals(user.username, 'username_algo')
+        self.assertEqual(user.email, 'email@example.com')
+        self.assertEqual(user.username, 'username_algo')
 
         token_mock.assert_called_once_with('id_token', nonce=None)
         request_mock.post.assert_called_once_with('https://server.example.com/token',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,7 +9,6 @@ except ImportError:
 
 from mock import patch
 
-import django
 from django.conf.urls import url
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_out
@@ -25,9 +24,6 @@ from mozilla_django_oidc.urls import urlpatterns as orig_urlpatterns
 
 
 User = get_user_model()
-
-
-DJANGO_VERSION = tuple(django.VERSION[0:2])
 
 
 class SessionRefreshTokenMiddlewareTestCase(TestCase):
@@ -163,9 +159,7 @@ def override_middleware(fun):
         'django.contrib.sessions.middleware.SessionMiddleware',
         'mozilla_django_oidc.middleware.SessionRefresh',
     ]
-    if DJANGO_VERSION >= (1, 10):
-        return override_settings(MIDDLEWARE=classes)(fun)
-    return override_settings(MIDDLEWARE_CLASSES=classes)(fun)
+    return override_settings(MIDDLEWARE=classes)(fun)
 
 
 class UserifiedClientHandler(ClientHandler):
@@ -338,13 +332,7 @@ class MiddlewareTestCase(TestCase):
             'error_description': 'Multifactor authentication required',
         })
         self.assertEqual(resp.status_code, 302)
-        # Note, in versions of Django <=1.8, this 'resp.url' will be
-        # an absolute URL, so we need to make this split to make sure the
-        # test suite works in old and new versions of Django.
-        if 'http://testserver' in resp.url:
-            self.assertEquals(resp.url, 'http://testserver/')
-        else:
-            self.assertEquals(resp.url, '/')
+        self.assertEquals(resp.url, '/')
 
         # Since the user in 'client' doesn't change, we have to use other
         # queues to assert that the user got logged out properly.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -68,12 +68,12 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
         request.user = self.user
 
         response = self.middleware.process_request(request)
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
         # The URL to go to is available both as a header and as a key
         # in the JSON response.
         self.assertTrue(response['refresh_url'])
         url, qs = response['refresh_url'].split('?')
-        self.assertEquals(url, 'http://example.com/authorize')
+        self.assertEqual(url, 'http://example.com/authorize')
         expected_query = {
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
@@ -83,9 +83,9 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'scope': ['openid email'],
             'state': ['examplestring'],
         }
-        self.assertEquals(expected_query, parse_qs(qs))
+        self.assertEqual(expected_query, parse_qs(qs))
         json_payload = json.loads(response.content.decode('utf-8'))
-        self.assertEquals(json_payload['refresh_url'], response['refresh_url'])
+        self.assertEqual(json_payload['refresh_url'], response['refresh_url'])
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='http://example.com/authorize')
     @override_settings(OIDC_RP_CLIENT_ID='foo')
@@ -100,9 +100,9 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
 
         response = self.middleware.process_request(request)
 
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         url, qs = response.url.split('?')
-        self.assertEquals(url, 'http://example.com/authorize')
+        self.assertEqual(url, 'http://example.com/authorize')
         expected_query = {
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
@@ -112,7 +112,7 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'scope': ['openid email'],
             'state': ['examplestring'],
         }
-        self.assertEquals(expected_query, parse_qs(qs))
+        self.assertEqual(expected_query, parse_qs(qs))
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='http://example.com/authorize')
     @override_settings(OIDC_RP_CLIENT_ID='foo')
@@ -129,9 +129,9 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
 
         response = self.middleware.process_request(request)
 
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         url, qs = response.url.split('?')
-        self.assertEquals(url, 'http://example.com/authorize')
+        self.assertEqual(url, 'http://example.com/authorize')
         expected_query = {
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
@@ -141,7 +141,7 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'scope': ['openid email'],
             'state': ['examplestring'],
         }
-        self.assertEquals(expected_query, parse_qs(qs))
+        self.assertEqual(expected_query, parse_qs(qs))
 
 
 # This adds a "home page" we can test against.
@@ -219,7 +219,7 @@ class MiddlewareTestCase(TestCase):
     @override_settings(OIDC_EXEMPT_URLS=['mdo_fake_view'])
     def test_get_exempt_urls_setting_view_name(self):
         middleware = SessionRefresh()
-        self.assertEquals(
+        self.assertEqual(
             sorted(list(middleware.exempt_urls)),
             [u'/authenticate/', u'/callback/', u'/logout/', u'/mdo_fake_view/']
         )
@@ -227,7 +227,7 @@ class MiddlewareTestCase(TestCase):
     @override_settings(OIDC_EXEMPT_URLS=['/foo/'])
     def test_get_exempt_urls_setting_url_path(self):
         middleware = SessionRefresh()
-        self.assertEquals(
+        self.assertEqual(
             sorted(list(middleware.exempt_urls)),
             [u'/authenticate/', u'/callback/', u'/foo/', u'/logout/']
         )
@@ -272,7 +272,7 @@ class MiddlewareTestCase(TestCase):
         self.assertEqual(resp.status_code, 302)
 
         url, qs = resp.url.split('?')
-        self.assertEquals(url, 'http://example.com/authorize')
+        self.assertEqual(url, 'http://example.com/authorize')
         expected_query = {
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
@@ -282,7 +282,7 @@ class MiddlewareTestCase(TestCase):
             'scope': ['openid email'],
             'state': ['examplestring'],
         }
-        self.assertEquals(expected_query, parse_qs(qs))
+        self.assertEqual(expected_query, parse_qs(qs))
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='http://example.com/authorize')
     @override_settings(OIDC_RP_CLIENT_ID='foo')
@@ -304,11 +304,11 @@ class MiddlewareTestCase(TestCase):
         # First confirm that the home page is a public page.
         resp = client.get('/')
         # At least security doesn't kick you out.
-        self.assertEquals(resp.status_code, 404)
+        self.assertEqual(resp.status_code, 404)
         # Also check that this page doesn't force you to redirect
         # to authenticate.
         resp = client.get('/mdo_fake_view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         client.login(username=self.user.username, password='password')
 
         # Set expiration to some time in the past
@@ -319,7 +319,7 @@ class MiddlewareTestCase(TestCase):
 
         # Confirm that now you're forced to authenticate again.
         resp = client.get('/mdo_fake_view/')
-        self.assertEquals(resp.status_code, 302)
+        self.assertEqual(resp.status_code, 302)
         self.assertTrue(
             'http://example.com/authorize' in resp.url and
             'prompt=none' in resp.url
@@ -332,7 +332,7 @@ class MiddlewareTestCase(TestCase):
             'error_description': 'Multifactor authentication required',
         })
         self.assertEqual(resp.status_code, 302)
-        self.assertEquals(resp.url, '/')
+        self.assertEqual(resp.url, '/')
 
         # Since the user in 'client' doesn't change, we have to use other
         # queues to assert that the user got logged out properly.
@@ -343,4 +343,4 @@ class MiddlewareTestCase(TestCase):
         self.assertTrue(not client.session.items())
 
         # The signal we registered should have fired for this user.
-        self.assertEquals(client.user, logged_out_users[0])
+        self.assertEqual(client.user, logged_out_users[0])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -309,7 +309,7 @@ class GetNextURLTestCase(TestCase):
             data={'next': 'https://testserver/foo'},
             secure=True,
         )
-        self.assertEquals(req.is_secure(), True)
+        self.assertEqual(req.is_secure(), True)
         next_url = views.get_next_url(req, 'next')
         self.assertEqual(next_url, 'https://testserver/foo')
 
@@ -319,7 +319,7 @@ class GetNextURLTestCase(TestCase):
             data={'next': 'http://testserver/foo'},
             secure=True,
         )
-        self.assertEquals(req.is_secure(), True)
+        self.assertEqual(req.is_secure(), True)
         next_url = views.get_next_url(req, 'next')
         self.assertEqual(next_url, None)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,11 +10,7 @@ import django
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 2.0.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase, override_settings
 
 from mozilla_django_oidc import views

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,7 +6,6 @@ except ImportError:
 
 from mock import patch
 
-import django
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
@@ -314,17 +313,15 @@ class GetNextURLTestCase(TestCase):
         next_url = views.get_next_url(req, 'next')
         self.assertEqual(next_url, 'https://testserver/foo')
 
-        # For Django 1.11+, if the request is for HTTPS and the next url is
-        # HTTP, then that fails.
-        if django.VERSION >= (1, 11):
-            req = self.factory.get(
-                '/',
-                data={'next': 'http://testserver/foo'},
-                secure=True,
-            )
-            self.assertEquals(req.is_secure(), True)
-            next_url = views.get_next_url(req, 'next')
-            self.assertEqual(next_url, None)
+        # If the request is for HTTPS and the next url is HTTP, then that fails.
+        req = self.factory.get(
+            '/',
+            data={'next': 'http://testserver/foo'},
+            secure=True,
+        )
+        self.assertEquals(req.is_secure(), True)
+        next_url = views.get_next_url(req, 'next')
+        self.assertEqual(next_url, None)
 
     @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_redirect_https_not_required(self):

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands = django-admin.py test
 setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
     PYTHONPATH={toxinidir}
+    PYTHONWARNINGS=default
 deps =
     -r{toxinidir}/tests/requirements.txt
     django111: Django>=1.11,<2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{27,34,35,36}-django111
     py{34,35,36,37}-django200
     py{35,36,37}-django210
+    py{35,36,37}-django220
 
 [travis]
 python =
@@ -26,6 +27,8 @@ deps =
     django200: djangorestframework>=3.7
     django210: Django>=2.1.0,<2.2
     django210: djangorestframework>=3.7
+    django220: Django>=2.2.0,<3.0
+    django220: djangorestframework>=3.7
 
 [testenv:coverage]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{34,35,36,37}-django200
     py{35,36,37}-django210
     py{35,36,37}-django220
+    py{36,37,38}-django300
 
 [travis]
 python =
@@ -13,6 +14,7 @@ python =
   3.5: py35
   3.6: py36
   3.7: py37, coverage, lint
+  3.8: py38
 
 [testenv]
 commands = django-admin.py test
@@ -29,6 +31,8 @@ deps =
     django210: djangorestframework>=3.7
     django220: Django>=2.2.0,<3.0
     django220: djangorestframework>=3.7
+    django300: Django>=3.0.0,<3.1
+    django300: djangorestframework>=3.7
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
This removes references to unsupported Django versions and backwards compatible code that is no longer required and adds Django 2.2 to the test matrices.