### PR TITLE
Update installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -212,7 +212,7 @@ the OIDC provider is still valid. You need to use the
 
 To add it to your site, put it in the settings::
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         # middleware involving session and authentication must come first
         # ...
         'mozilla_django_oidc.middleware.SessionRefresh',


### PR DESCRIPTION
Updates installation docs to reference current/newer variable name for the middleware configuration. `MIDDLEWARE` should be used over `MIDDLEWARE_CLASSES`, which was deprecated with Django 2.0 (https://docs.djangoproject.com/en/2.2/releases/2.0/)