### PR TITLE
docs(DRF): Fix OIDC_DRF_AUTH_BACKEND reference

### DIFF
--- a/docs/drf.rst
+++ b/docs/drf.rst
@@ -26,4 +26,4 @@ figure that out. Alternatively, you can manually set the OIDC backend to use:
 
 .. code-block:: python
 
-	OIDC_DRF_AUTH_BACKEND = 'mozilla_django_oidc.OIDCAuthenticationBackend'
+	OIDC_DRF_AUTH_BACKEND = 'mozilla_django_oidc.auth.OIDCAuthenticationBackend'


### PR DESCRIPTION
There is a typo to an unresolved class on DRF docs, this changes that to point to auth module