### PR TITLE
fix(Middleware): Check settings for callback URL

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -111,7 +111,8 @@ class SessionRefresh(MiddlewareMixin):
             'client_id': client_id,
             'redirect_uri': absolutify(
                 request,
-                reverse('oidc_authentication_callback')
+                reverse(self.get_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
+                                          'oidc_authentication_callback'))
             ),
             'state': state,
             'scope': self.get_settings('OIDC_RP_SCOPES', 'openid email'),


### PR DESCRIPTION
There is a `settings.OIDC_AUTHENTICATION_CALLBACK_URL` which is obeyed in `auth.py`. This makes it uniform and redirects to the correct endpoint