### PR TITLE
Add SessionAuthentication to DRF auth classes

### DIFF
--- a/docs/drf.rst
+++ b/docs/drf.rst
@@ -13,6 +13,7 @@ Add this to your settings:
     REST_FRAMEWORK = {
         'DEFAULT_AUTHENTICATION_CLASSES': [
             'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
+            'rest_framework.authentication.SessionAuthentication',
             # other authentication classes, if needed
         ],
     }


### PR DESCRIPTION
DRF will not authenticate properly if SessionAuthentication is not added.

See #328, #265, and [StackOverflow question](https://stackoverflow.com/questions/35601130/django-rest-framework-using-tokenauthentication-with-browsable-api)