### PR TITLE
Added configuration options to define a timeout and a proxy

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -53,6 +53,26 @@ of ``mozilla-django-oidc``.
 
    Controls whether the OpenID Connect client verifies the SSL certificate of the OP responses
 
+.. py:attribute:: OIDC_TIMEOUT
+
+   :default: ``None``
+
+    Defines a timeout for all requests to the OpenID Connect provider (fetch JWS,
+    retrieve JWT tokens, Userinfo Endpoint). The default is set to `None` which means
+    the library will wait indefinitely. The time can be defined as seconds (integer).
+    More information about possible configuration values, see Python `requests`:
+    https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
+
+.. py:attribute:: OIDC_PROXY
+
+   :default: ``None``
+
+    Defines a proxy for all requests to the OpenID Connect provider (fetch JWS,
+    retrieve JWT tokens, Userinfo Endpoint). The default is set to `None` which means
+    the library will not use a proxy and connect directly. For configuring a proxy
+    check the Python `requests` documentation:
+    https://requests.readthedocs.io/en/master/user/advanced/#proxies
+
 .. py:attribute:: OIDC_EXEMPT_URLS
 
    :default: ``[]``

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -141,7 +141,9 @@ class OIDCAuthenticationBackend(ModelBackend):
         """Get the signing key by exploring the JWKS endpoint of the OP."""
         response_jwks = requests.get(
             self.OIDC_OP_JWKS_ENDPOINT,
-            verify=self.get_settings('OIDC_VERIFY_SSL', True)
+            verify=self.get_settings('OIDC_VERIFY_SSL', True),
+            timeout=self.get_settings('OIDC_TIMEOUT', None),
+            proxies=self.get_settings('OIDC_PROXY', None)
         )
         response_jwks.raise_for_status()
         jwks = response_jwks.json()
@@ -221,7 +223,9 @@ class OIDCAuthenticationBackend(ModelBackend):
             self.OIDC_OP_TOKEN_ENDPOINT,
             data=payload,
             auth=auth,
-            verify=self.get_settings('OIDC_VERIFY_SSL', True))
+            verify=self.get_settings('OIDC_VERIFY_SSL', True),
+            timeout=self.get_settings('OIDC_TIMEOUT', None),
+            proxies=self.get_settings('OIDC_PROXY', None))
         response.raise_for_status()
         return response.json()
 
@@ -234,7 +238,9 @@ class OIDCAuthenticationBackend(ModelBackend):
             headers={
                 'Authorization': 'Bearer {0}'.format(access_token)
             },
-            verify=self.get_settings('OIDC_VERIFY_SSL', True))
+            verify=self.get_settings('OIDC_VERIFY_SSL', True),
+            timeout=self.get_settings('OIDC_TIMEOUT', None),
+            proxies=self.get_settings('OIDC_PROXY', None))
         user_response.raise_for_status()
         return user_response.json()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -256,11 +256,15 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.assert_called_once_with('https://server.example.com/token',
                                                   data=post_data,
                                                   auth=None,
-                                                  verify=True)
+                                                  verify=True,
+                                                  timeout=None,
+                                                  proxies=None)
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None
         )
 
     @patch('mozilla_django_oidc.auth.requests')
@@ -299,11 +303,15 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.assert_called_once_with('https://server.example.com/token',
                                                   data=post_data,
                                                   auth=None,
-                                                  verify=True)
+                                                  verify=True,
+                                                  timeout=None,
+                                                  proxies=None)
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None
         )
 
     @override_settings(OIDC_STORE_ACCESS_TOKEN=True)
@@ -344,11 +352,15 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.assert_called_once_with('https://server.example.com/token',
                                                   data=post_data,
                                                   auth=None,
-                                                  verify=True)
+                                                  verify=True,
+                                                  timeout=None,
+                                                  proxies=None)
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None
         )
         self.assertEqual(auth_request.session.get('oidc_id_token'), 'id_token')
         self.assertEqual(auth_request.session.get('oidc_access_token'), 'access_granted')
@@ -393,11 +405,15 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.assert_called_once_with('https://server.example.com/token',
                                                   data=post_data,
                                                   auth=None,
-                                                  verify=True)
+                                                  verify=True,
+                                                  timeout=None,
+                                                  proxies=None)
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None
         )
 
     @patch.object(settings, 'OIDC_USERNAME_ALGO')
@@ -441,11 +457,15 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.post.assert_called_once_with('https://server.example.com/token',
                                                   data=post_data,
                                                   auth=None,
-                                                  verify=True)
+                                                  verify=True,
+                                                  timeout=None,
+                                                  proxies=None)
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None,
         )
 
     @override_settings(OIDC_TOKEN_USE_BASIC_AUTH=True)
@@ -510,7 +530,9 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         request_mock.get.assert_called_once_with(
             'https://server.example.com/user',
             headers={'Authorization': 'Bearer access_granted'},
-            verify=True
+            verify=True,
+            timeout=None,
+            proxies=None
         )
         self.assertEqual(auth_request.session.get('oidc_id_token'), 'id_token')
         self.assertEqual(auth_request.session.get('oidc_access_token'), 'access_granted')


### PR DESCRIPTION
**Timeout**
Currently all requests to the OpenID Connect provider have no timeout set in the python `requests` GET and POST requests (3 in total). This means if the OIDC Provider is very slow or not reachable, the `mozilla-django-oidc` library will hang indefinitely.

With this merge request you can now define the `OIDC_TIMEOUT` value. Default value is `None` to be backwards compatible with the current situation.

Example:
```
OIDC_TIMEOUT = 10
```

**Proxy**
In case the OIDC Provider can only be reached via a proxy server from the library, the proxy can now be defined with the `OIDC_PROXY` settings variable. The default value is also `None` to be backwards compatible.

Example:
```
OIDC_PROXY = {
    'https': 'http://proxy.example.org:8000',
}