### PR TITLE
Allow multiple parallel login sessions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -159,37 +159,29 @@ Django templates example:
 
 .. code-block:: html+django
 
-   <html>
-     <body>
-       {% if user.is_authenticated %}
-         <p>Current user: {{ user.email }}</p>
-         <form action="{% url 'oidc_logout' %}" method="post">
-           <input type="submit" value="logout">
-         </form>
-       {% else %}
-         <a href="{% url 'oidc_authentication_init' %}">Login</a>
-       {% endif %}
-     </body>
-   </html>
-
+   {% if user.is_authenticated %}
+     <p>Current user: {{ user.email }}</p>
+     <form action="{% url 'oidc_logout' %}" method="post">
+       {% csrf_token %}
+       <input type="submit" value="logout">
+     </form>
+   {% else %}
+     <a href="{% url 'oidc_authentication_init' %}">Login</a>
+   {% endif %}
 
 Jinja2 templates example:
 
 .. code-block:: html+jinja
 
-   <html>
-     <body>
-       {% if user.is_authenticated() %}
-         <p>Current user: {{ user.email }}</p>
-         <form action="{% url('oidc_logout') %}" method="post">
-           <input type="submit" value="logout">
-         </form>
-       {% else %}
-         <a href="{{ url('oidc_authentication_init') }}">Login</a>
-       {% endif %}
-     </body>
-   </html>
-
+   {% if request.user.is_authenticated %}
+     <p>Current user: {{ request.user.email }}</p>
+     <form action="{{ url('oidc_logout') }}" method="post">
+       {{ csrf_input }}
+       <input type="submit" value="logout">
+     </form>
+   {% else %}
+     <a href="{{ url('oidc_authentication_init') }}">Login</a>
+   {% endif %}
 
 Additional optional configuration
 =================================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -79,6 +79,13 @@ of ``mozilla-django-oidc``.
 
    Sets the length of the random string used for OpenID Connect nonce verification
 
+.. py:attribute:: OIDC_MAX_STATES
+
+   :default: ``50``
+
+   Sets the maximum number of State / Nonce combinations stored in the session.
+   Multiple combinations are used when the user does multiple concurrent login sessions.
+
 .. py:attribute:: OIDC_REDIRECT_FIELD_NAME
 
    :default: ``next``

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -15,8 +15,8 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
-from mozilla_django_oidc.utils import absolutify, import_from_settings
-
+from mozilla_django_oidc.utils import absolutify, import_from_settings,\
+    add_state_and_nonce_to_session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -111,14 +111,8 @@ class SessionRefresh(MiddlewareMixin):
             'prompt': 'none',
         }
 
-        if self.get_settings('OIDC_USE_NONCE', True):
-            nonce = get_random_string(self.get_settings('OIDC_NONCE_SIZE', 32))
-            params.update({
-                'nonce': nonce
-            })
-            request.session['oidc_nonce'] = nonce
+        add_state_and_nonce_to_session(request, state, params)
 
-        request.session['oidc_state'] = state
         request.session['oidc_login_next'] = request.get_full_path()
 
         query = urlencode(params)

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import logging
+import time
 import warnings
 
 try:
@@ -84,7 +84,7 @@ def add_state_and_nonce_to_session(request, state, params):
     if len(request.session['oidc_states']) >= limit:
         LOGGER.warning('User has more than {} "oidc_states" in his session, deleting the oldest one!'.format(limit))
         oldest_state = None
-        oldest_added_on = datetime.now().timestamp()  # use float because datetime is not JSON serializable
+        oldest_added_on = time.time()
         for item_state, item in request.session['oidc_states'].items():
             if item['added_on'] < oldest_added_on:
                 oldest_state = item_state
@@ -94,5 +94,5 @@ def add_state_and_nonce_to_session(request, state, params):
 
     request.session['oidc_states'][state] = {
         'nonce': nonce,
-        'added_on': datetime.now().timestamp(),  # use float because datetime is not JSON serializable
+        'added_on': time.time(),
     }

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -60,6 +60,12 @@ def is_authenticated(user):
 
 
 def add_state_and_nonce_to_session(request, state, params):
+    """
+    Stores the `state` and `nonce` parameters in a session dictionary including the time when it was added.
+    The dictionary can contain multiple state/nonce combinations to allow parallel logins with multiple browser
+    sessions.
+    To keep the session space to a reasonable size, the dictionary is kept at 50 state/nonce combinations maximum.
+    """
     nonce = None
     if import_from_settings('OIDC_USE_NONCE', True):
         nonce = get_random_string(import_from_settings('OIDC_NONCE_SIZE', 32))

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+import logging
 import warnings
 
 try:
@@ -9,6 +11,9 @@ except ImportError:
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import get_random_string
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def parse_www_authenticate_header(header):
@@ -62,16 +67,32 @@ def add_state_and_nonce_to_session(request, state, params):
             'nonce': nonce
         })
 
-    # Store Nonce with the state parameter in the session "oidc_states" dictionary.
-    # The dictionary can store multiple state/nonce combinations to allow parallel
-    # authentication flows which would otherwise overwrite state/nonce values!
-
-    # Initialize 'oidc_states' dictionary. Make sure the dictionary does not get
-    # too big by resetting the dictionary if there are more than 20 entries
-    # (unlikely to reach so many parallel login sessions at the same time).
+    # Store Nonce with the State parameter in the session "oidc_states" dictionary.
+    # The dictionary can store multiple State/Nonce combinations to allow parallel
+    # authentication flows which would otherwise overwrite State/Nonce values!
+    # The "oidc_states" dictionary uses the state as key and as value a dictionary with "nonce" and "added_on".
+    # "added_on" contains the time when the state was added to the session. With this value, the oldest element
+    # can be found and deleted from the session.
     if 'oidc_states' not in request.session or \
-            not isinstance(request.session['oidc_states'], dict) or \
-            len(request.session['oidc_states']) > 20:
+            not isinstance(request.session['oidc_states'], dict):
         request.session['oidc_states'] = {}
 
-    request.session['oidc_states'][state] = nonce
+    # Make sure that the State/Nonce dictionary in the session does not get too big.
+    # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest state by finding out
+    # which element has the oldest "add_on" time.
+    limit = import_from_settings('OIDC_MAX_STATES', 50)
+    if len(request.session['oidc_states']) >= limit:
+        LOGGER.warning('User has more than {} "oidc_states" in his session, deleting the oldest one!'.format(limit))
+        oldest_state = None
+        oldest_added_on = datetime.now().timestamp()  # use float because datetime is not JSON serializable
+        for item_state, item in request.session['oidc_states'].items():
+            if item['added_on'] < oldest_added_on:
+                oldest_state = item_state
+                oldest_added_on = item['added_on']
+        if oldest_state:
+            del request.session['oidc_states'][oldest_state]
+
+    request.session['oidc_states'][state] = {
+        'nonce': nonce,
+        'added_on': datetime.now().timestamp(),  # use float because datetime is not JSON serializable
+    }

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -61,10 +61,11 @@ def is_authenticated(user):
 
 def add_state_and_nonce_to_session(request, state, params):
     """
-    Stores the `state` and `nonce` parameters in a session dictionary including the time when it was added.
-    The dictionary can contain multiple state/nonce combinations to allow parallel logins with multiple browser
-    sessions.
-    To keep the session space to a reasonable size, the dictionary is kept at 50 state/nonce combinations maximum.
+    Stores the `state` and `nonce` parameters in a session dictionary including the time when it
+    was added. The dictionary can contain multiple state/nonce combinations to allow parallel
+    logins with multiple browser sessions.
+    To keep the session space to a reasonable size, the dictionary is kept at 50 state/nonce
+    combinations maximum.
     """
     nonce = None
     if import_from_settings('OIDC_USE_NONCE', True):

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -70,19 +70,23 @@ def add_state_and_nonce_to_session(request, state, params):
     # Store Nonce with the State parameter in the session "oidc_states" dictionary.
     # The dictionary can store multiple State/Nonce combinations to allow parallel
     # authentication flows which would otherwise overwrite State/Nonce values!
-    # The "oidc_states" dictionary uses the state as key and as value a dictionary with "nonce" and "added_on".
-    # "added_on" contains the time when the state was added to the session. With this value, the oldest element
-    # can be found and deleted from the session.
+    # The "oidc_states" dictionary uses the state as key and as value a dictionary with "nonce"
+    # and "added_on". "added_on" contains the time when the state was added to the session.
+    # With this value, the oldest element can be found and deleted from the session.
     if 'oidc_states' not in request.session or \
             not isinstance(request.session['oidc_states'], dict):
         request.session['oidc_states'] = {}
 
     # Make sure that the State/Nonce dictionary in the session does not get too big.
-    # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest state by finding out
+    # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest
+    # state by finding out
     # which element has the oldest "add_on" time.
     limit = import_from_settings('OIDC_MAX_STATES', 50)
     if len(request.session['oidc_states']) >= limit:
-        LOGGER.warning('User has more than {} "oidc_states" in his session, deleting the oldest one!'.format(limit))
+        LOGGER.warning(
+            'User has more than {} "oidc_states" in his session, '
+            'deleting the oldest one!'.format(limit)
+        )
         oldest_state = None
         oldest_added_on = time.time()
         for item_state, item in request.session['oidc_states'].items():

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -70,7 +70,7 @@ class OIDCAuthenticationCallbackView(View):
                 return self.login_failure()
 
             # State and Nonce are stored in the session "oidc_states" dictionary.
-            # State is the key, Nonce the value.
+            # State is the key, the value is a dictionary with the Nonce in the "nonce" field.
             state = request.GET.get('state')
             if state not in request.session['oidc_states']:
                 msg = 'OIDC callback state not found in session `oidc_states`!'
@@ -78,7 +78,7 @@ class OIDCAuthenticationCallbackView(View):
 
             # Get the nonce from the dictionary for further processing and delete the entry to
             # prevent replay attacks.
-            nonce = request.session['oidc_states'][state]
+            nonce = request.session['oidc_states'][state]['nonce']
             del request.session['oidc_states'][state]
 
             kwargs = {

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -81,6 +81,14 @@ class OIDCAuthenticationCallbackView(View):
             nonce = request.session['oidc_states'][state]['nonce']
             del request.session['oidc_states'][state]
 
+            # Authenticating is slow, so save the updated oidc_states.
+            request.session.save()
+            # Reset the session. This forces the session to get reloaded from the database after
+            # fetching the token from the OpenID connect provider.
+            # Without this step we would overwrite items that are being added/removed from the
+            # session in parallel browser tabs.
+            request.session = request.session.__class__(request.session.session_key)
+
             kwargs = {
                 'request': request,
                 'nonce': nonce,

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -14,7 +14,8 @@ from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from django.views.generic import View
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings
+from mozilla_django_oidc.utils import absolutify, import_from_settings,\
+    add_state_and_nonce_to_session
 
 
 class OIDCAuthenticationCallbackView(View):
@@ -53,11 +54,6 @@ class OIDCAuthenticationCallbackView(View):
     def get(self, request):
         """Callback handler for OIDC authorization code flow"""
 
-        nonce = request.session.get('oidc_nonce')
-        if nonce:
-            # Make sure that nonce is not used twice
-            del request.session['oidc_nonce']
-
         if request.GET.get('error'):
             # Ouch! Something important failed.
             # Make sure the user doesn't get to continue to be logged in
@@ -68,17 +64,27 @@ class OIDCAuthenticationCallbackView(View):
                 auth.logout(request)
             assert not request.user.is_authenticated
         elif 'code' in request.GET and 'state' in request.GET:
+
+            # Check instead of "oidc_state" check if the "oidc_states" session key exists!
+            if 'oidc_states' not in request.session:
+                return self.login_failure()
+
+            # State and Nonce are stored in the session "oidc_states" dictionary.
+            # State is the key, Nonce the value.
+            state = request.GET.get('state')
+            if state not in request.session['oidc_states']:
+                msg = 'OIDC callback state not found in session `oidc_states`!'
+                raise SuspiciousOperation(msg)
+
+            # Get the nonce from the dictionary for further processing and delete the entry to
+            # prevent replay attacks.
+            nonce = request.session['oidc_states'][state]
+            del request.session['oidc_states'][state]
+
             kwargs = {
                 'request': request,
                 'nonce': nonce,
             }
-
-            if 'oidc_state' not in request.session:
-                return self.login_failure()
-
-            if request.GET['state'] != request.session['oidc_state']:
-                msg = 'Session `oidc_state` does not match the OIDC callback state'
-                raise SuspiciousOperation(msg)
 
             self.user = auth.authenticate(**kwargs)
 
@@ -152,14 +158,8 @@ class OIDCAuthenticationRequestView(View):
 
         params.update(self.get_extra_params(request))
 
-        if self.get_settings('OIDC_USE_NONCE', True):
-            nonce = get_random_string(self.get_settings('OIDC_NONCE_SIZE', 32))
-            params.update({
-                'nonce': nonce
-            })
-            request.session['oidc_nonce'] = nonce
+        add_state_and_nonce_to_session(request, state, params)
 
-        request.session['oidc_state'] = state
         request.session['oidc_login_next'] = get_next_url(request, redirect_field_name)
 
         query = urlencode(params)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -57,8 +57,10 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='foo')
     @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
     @patch('mozilla_django_oidc.middleware.get_random_string')
-    def test_is_ajax(self, mock_random_string):
-        mock_random_string.return_value = 'examplestring'
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_is_ajax(self, mock_utils_random, mock_middleware_random):
+        mock_middleware_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
 
         request = self.factory.get(
             '/foo',
@@ -78,7 +80,7 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
             'client_id': ['foo'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'prompt': ['none'],
             'scope': ['openid email'],
             'state': ['examplestring'],
@@ -91,8 +93,11 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='foo')
     @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
     @patch('mozilla_django_oidc.middleware.get_random_string')
-    def test_no_oidc_token_expiration_forces_renewal(self, mock_random_string):
-        mock_random_string.return_value = 'examplestring'
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_no_oidc_token_expiration_forces_renewal(self, mock_utils_random,
+                                                     mock_middleware_random):
+        mock_middleware_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
 
         request = self.factory.get('/foo')
         request.user = self.user
@@ -107,7 +112,7 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
             'client_id': ['foo'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'prompt': ['none'],
             'scope': ['openid email'],
             'state': ['examplestring'],
@@ -118,8 +123,10 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='foo')
     @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
     @patch('mozilla_django_oidc.middleware.get_random_string')
-    def test_expired_token_forces_renewal(self, mock_random_string):
-        mock_random_string.return_value = 'examplestring'
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_expired_token_forces_renewal(self, mock_utils_random, mock_middleware_random):
+        mock_middleware_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
 
         request = self.factory.get('/foo')
         request.user = self.user
@@ -136,7 +143,7 @@ class SessionRefreshTokenMiddlewareTestCase(TestCase):
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
             'client_id': ['foo'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'prompt': ['none'],
             'scope': ['openid email'],
             'state': ['examplestring'],
@@ -256,8 +263,10 @@ class MiddlewareTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='foo')
     @override_settings(OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=120)
     @patch('mozilla_django_oidc.middleware.get_random_string')
-    def test_expired_token_redirects_to_sso(self, mock_random_string):
-        mock_random_string.return_value = 'examplestring'
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_expired_token_redirects_to_sso(self, mock_utils_random, mock_middleware_random):
+        mock_middleware_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
 
         client = ClientWithUser()
         client.login(username=self.user.username, password='password')
@@ -277,7 +286,7 @@ class MiddlewareTestCase(TestCase):
             'response_type': ['code'],
             'redirect_uri': ['http://testserver/callback/'],
             'client_id': ['foo'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'prompt': ['none'],
             'scope': ['openid email'],
             'state': ['examplestring'],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings
+from mozilla_django_oidc.utils import absolutify, add_state_and_nonce_to_session, import_from_settings
 
 
 class SettingImportTestCase(TestCase):
@@ -47,3 +48,102 @@ class AbsolutifyTestCase(TestCase):
         ).get('/', SERVER_PORT=443)
         url = absolutify(req, 'evil.com/foo/bar')
         self.assertEqual(url, 'https://testserver/evil.com/foo/bar')
+
+
+class SessionStateTestCase(TestCase):
+
+    def setUp(self) -> None:
+        self.request = RequestFactory().get('/doesnt/matter')
+
+        # Setup request with a session for testing
+        middleware = SessionMiddleware()
+        middleware.process_request(self.request)
+        self.request.session.save()
+
+    def test_add_state_to_session(self):
+        state = 'example_state'
+        params = {}
+
+        add_state_and_nonce_to_session(self.request, state, params)
+
+        self.assertIn('nonce', params)
+        self.assertIn('oidc_states', self.request.session)
+        self.assertEqual(1, len(self.request.session['oidc_states']))
+        self.assertIn(state, self.request.session['oidc_states'].keys())
+
+    def test_existing_params(self):
+        state = 'example_state'
+
+        param_key = 'example_param'
+        params = {
+            param_key: 'example',
+        }
+
+        add_state_and_nonce_to_session(self.request, state, params)
+
+        self.assertIn('nonce', params)
+        self.assertIn(param_key, params)
+
+    def test_multiple_states(self):
+        state1 = 'example_state_1'
+        state2 = 'example_state_2'
+        params = {}
+
+        add_state_and_nonce_to_session(self.request, state1, params)
+
+        self.assertEqual(1, len(self.request.session['oidc_states']))
+        self.assertIn(state1, self.request.session['oidc_states'].keys())
+
+        add_state_and_nonce_to_session(self.request, state2, params)
+
+        self.assertEqual(2, len(self.request.session['oidc_states']))
+        self.assertIn(state1, self.request.session['oidc_states'].keys())
+        self.assertIn(state2, self.request.session['oidc_states'].keys())
+
+    def test_max_states(self):
+        limit = import_from_settings('OIDC_MAX_STATES', 50)
+
+        first_state = 'example_state_0'
+        params = {}
+        for i in range(limit):
+            state = 'example_state_{}'.format(i)
+            add_state_and_nonce_to_session(self.request, state, params)
+
+        self.assertEqual(limit, len(self.request.session['oidc_states']))
+        self.assertIn(first_state, self.request.session['oidc_states'])
+
+        # Add another state which should remove the very first one
+        additional_state = 'example_state'
+        add_state_and_nonce_to_session(self.request, additional_state, params)
+
+        # Make sure the oldest state was deleted
+        self.assertNotIn(first_state, self.request.session['oidc_states'])
+
+        # New state should be in the list but length should not have changed
+        self.assertEqual(limit, len(self.request.session['oidc_states']))
+        self.assertIn(additional_state, self.request.session['oidc_states'].keys())
+
+    @override_settings(OIDC_USE_NONCE=False)
+    def test_state_dictionary_without_nonce_format(self):
+        state = 'example_state'
+        params = {}
+
+        add_state_and_nonce_to_session(self.request, state, params)
+
+        # Test state dictionary
+        self.assertIn(state, self.request.session['oidc_states'].keys())
+        self.assertTrue(isinstance(self.request.session['oidc_states'][state], dict))
+
+        # Test nonce
+        self.assertEqual(self.request.session['oidc_states'][state]['nonce'], None)
+
+        # Test added_on timestamp
+        self.assertTrue(isinstance(self.request.session['oidc_states'][state]['added_on'], float))
+
+    def test_state_dictionary_with_nonce_format(self):
+        state = 'example_state'
+        params = {}
+
+        add_state_and_nonce_to_session(self.request, state, params)
+
+        self.assertTrue(isinstance(self.request.session['oidc_states'][state]['nonce'], str))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,4 +146,4 @@ class SessionStateTestCase(TestCase):
 
         add_state_and_nonce_to_session(self.request, state, params)
 
-        self.assertTrue(isinstance(self.request.session['oidc_states'][state]['nonce'], str))
+        self.assertNotEqual(self.request.session['oidc_states'][state]['nonce'], None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,7 @@ class AbsolutifyTestCase(TestCase):
 
 class SessionStateTestCase(TestCase):
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.request = RequestFactory().get('/doesnt/matter')
 
         # Setup request with a session for testing

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
-from mozilla_django_oidc.utils import absolutify, add_state_and_nonce_to_session, import_from_settings
+from mozilla_django_oidc.utils import absolutify, add_state_and_nonce_to_session, \
+    import_from_settings
 
 
 class SettingImportTestCase(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,7 +12,7 @@ from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings, Client
 
 from mozilla_django_oidc import views
 
@@ -39,9 +39,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         }
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
-        }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -67,10 +67,10 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         }
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}},
-            'oidc_login_next': '/foobar'
-        }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
+        request.session['oidc_login_next'] = '/foobar'
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -95,9 +95,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
 
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
-        }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -124,9 +124,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
 
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
-        }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -214,10 +214,10 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         }
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {'example_state': {'nonce': 'example_nonce', 'added_on': time.time()}},
-            'oidc_nonce': 'example_nonce'
-        }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {'example_state': {'nonce': 'example_nonce', 'added_on': time.time()}}
+        request.session['oidc_nonce'] = 'example_nonce'
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -241,11 +241,11 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         }
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
-        request.session = {
-            'oidc_states': {
-                'example_state': {'nonce': None, 'added_on': time.time()},
-                'example_state2': {'nonce': None, 'added_on': time.time()},
-            }
+        client = Client()
+        request.session = client.session
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': None, 'added_on': time.time()},
+            'example_state2': {'nonce': None, 'added_on': time.time()},
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
         callback_view(request)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import time
 
 try:
     from urllib.parse import parse_qs, urlparse
@@ -40,7 +40,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -68,7 +68,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}},
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}},
             'oidc_login_next': '/foobar'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -96,7 +96,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -125,7 +125,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': time.time()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -215,7 +215,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': {'nonce': 'example_nonce', 'added_on': datetime.now().timestamp()}},
+            'oidc_states': {'example_state': {'nonce': 'example_nonce', 'added_on': time.time()}},
             'oidc_nonce': 'example_nonce'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -243,8 +243,8 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         request.session = {
             'oidc_states': {
-                'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()},
-                'example_state2': {'nonce': None, 'added_on': datetime.now().timestamp()},
+                'example_state': {'nonce': None, 'added_on': time.time()},
+                'example_state2': {'nonce': None, 'added_on': time.time()},
             }
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -41,7 +41,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         client = Client()
         request.session = client.session
-        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': None, 'added_on': time.time()},
+        }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -69,7 +71,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         client = Client()
         request.session = client.session
-        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': None, 'added_on': time.time()},
+        }
         request.session['oidc_login_next'] = '/foobar'
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -97,7 +101,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         client = Client()
         request.session = client.session
-        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': None, 'added_on': time.time()},
+        }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -126,7 +132,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         client = Client()
         request.session = client.session
-        request.session['oidc_states'] = {'example_state': {'nonce': None, 'added_on': time.time()}}
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': None, 'added_on': time.time()},
+        }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with patch('mozilla_django_oidc.views.auth.authenticate') as mock_auth:
@@ -216,7 +224,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         client = Client()
         request.session = client.session
-        request.session['oidc_states'] = {'example_state': {'nonce': 'example_nonce', 'added_on': time.time()}}
+        request.session['oidc_states'] = {
+            'example_state': {'nonce': 'example_nonce', 'added_on': time.time()},
+        }
         request.session['oidc_nonce'] = 'example_nonce'
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -38,7 +38,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'example_state'
+            'oidc_states': {'example_state': None}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -66,7 +66,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'example_state',
+            'oidc_states': {'example_state': None},
             'oidc_login_next': '/foobar'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -94,7 +94,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'example_state'
+            'oidc_states': {'example_state': None}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -123,7 +123,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'example_state'
+            'oidc_states': {'example_state': None}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -191,14 +191,14 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'tampered_state'
+            'oidc_states': {'tampered_state': None}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
         with self.assertRaises(SuspiciousOperation) as context:
             callback_view(request)
 
-        expected_error_message = 'Session `oidc_state` does not match the OIDC callback state'
+        expected_error_message = 'OIDC callback state not found in session `oidc_states`!'
         self.assertEqual(context.exception.args, (expected_error_message,))
 
     @override_settings(LOGIN_REDIRECT_URL='/success')
@@ -213,7 +213,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_state': 'example_state',
+            'oidc_states': {'example_state': 'example_nonce'},
             'oidc_nonce': 'example_nonce'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -229,7 +229,27 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, '/success')
-        self.assertTrue('oidc_nonce' not in request.session)
+        self.assertTrue('example_state' not in request.session['oidc_states'])
+
+    def test_multiple_login_sessions(self):
+        """Test if states/nonces of other login sessions remain in the 'oidc_states' dictionary."""
+        get_data = {
+            'code': 'example_code',
+            'state': 'example_state'
+        }
+        url = reverse('oidc_authentication_callback')
+        request = self.factory.get(url, get_data)
+        request.session = {
+            'oidc_states': {
+                'example_state': None,
+                'example_state2': None,
+            }
+        }
+        callback_view = views.OIDCAuthenticationCallbackView.as_view()
+        callback_view(request)
+
+        self.assertFalse('example_state' in request.session['oidc_states'])
+        self.assertTrue('example_state2' in request.session['oidc_states'])
 
 
 class GetNextURLTestCase(TestCase):
@@ -353,9 +373,11 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='https://server.example.com/auth')
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @patch('mozilla_django_oidc.views.get_random_string')
-    def test_get(self, mock_random_string):
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_get(self, mock_utils_random, mock_views_random):
         """Test initiation of a successful OIDC attempt."""
-        mock_random_string.return_value = 'examplestring'
+        mock_views_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
         url = reverse('oidc_authentication_init')
         request = self.factory.get(url)
         request.session = dict()
@@ -370,7 +392,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             'client_id': ['example_id'],
             'redirect_uri': ['http://testserver/callback/'],
             'state': ['examplestring'],
-            'nonce': ['examplestring']
+            'nonce': ['examplenonce']
         }
         self.assertDictEqual(parse_qs(o.query), expected_query)
         self.assertEqual(o.hostname, 'server.example.com')
@@ -381,9 +403,11 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @override_settings(OIDC_AUTHENTICATION_CALLBACK_URL='namespace:oidc_authentication_callback')
     @patch('mozilla_django_oidc.views.get_random_string')
-    def test_get_namespaced(self, mock_random_string):
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_get_namespaced(self, mock_utils_random, mock_views_random):
         """Test initiation of a successful OIDC attempt with namespaced redirect_uri."""
-        mock_random_string.return_value = 'examplestring'
+        mock_views_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
         url = reverse('namespace:oidc_authentication_init')
         request = self.factory.get(url)
         request.session = dict()
@@ -398,7 +422,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             'client_id': ['example_id'],
             'redirect_uri': ['http://testserver/namespace/callback/'],
             'state': ['examplestring'],
-            'nonce': ['examplestring']
+            'nonce': ['examplenonce']
         }
         self.assertDictEqual(parse_qs(o.query), expected_query)
         self.assertEqual(o.hostname, 'server.example.com')
@@ -408,9 +432,11 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @override_settings(OIDC_AUTH_REQUEST_EXTRA_PARAMS={'audience': 'some-api.example.com'})
     @patch('mozilla_django_oidc.views.get_random_string')
-    def test_get_with_audience(self, mock_random_string):
+    @patch('mozilla_django_oidc.utils.get_random_string')
+    def test_get_with_audience(self, mock_utils_random, mock_views_random):
         """Test initiation of a successful OIDC attempt."""
-        mock_random_string.return_value = 'examplestring'
+        mock_views_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
         url = reverse('oidc_authentication_init')
         request = self.factory.get(url)
         request.session = dict()
@@ -425,7 +451,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             'client_id': ['example_id'],
             'redirect_uri': ['http://testserver/callback/'],
             'state': ['examplestring'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'audience': ['some-api.example.com'],
         }
         self.assertDictEqual(parse_qs(o.query), expected_query)
@@ -435,10 +461,13 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT='https://server.example.com/auth')
     @override_settings(OIDC_RP_CLIENT_ID='example_id')
     @patch('mozilla_django_oidc.views.get_random_string')
+    @patch('mozilla_django_oidc.utils.get_random_string')
     @patch('mozilla_django_oidc.views.OIDCAuthenticationRequestView.get_extra_params')
-    def test_get_with_overridden_extra_params(self, mock_extra_params, mock_random_string):
+    def test_get_with_overridden_extra_params(self, mock_extra_params, mock_utils_random,
+                                              mock_views_random):
         """Test overriding OIDCAuthenticationRequestView.get_extra_params()."""
-        mock_random_string.return_value = 'examplestring'
+        mock_views_random.return_value = 'examplestring'
+        mock_utils_random.return_value = 'examplenonce'
 
         mock_extra_params.return_value = {
             'connection': 'foo'
@@ -458,7 +487,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             'client_id': ['example_id'],
             'redirect_uri': ['http://testserver/callback/'],
             'state': ['examplestring'],
-            'nonce': ['examplestring'],
+            'nonce': ['examplenonce'],
             'connection': ['foo'],
         }
         self.assertDictEqual(parse_qs(o.query), expected_query)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 try:
     from urllib.parse import parse_qs, urlparse
 except ImportError:
@@ -38,7 +40,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': None}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -66,7 +68,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': None},
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}},
             'oidc_login_next': '/foobar'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -94,7 +96,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': None}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -123,7 +125,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': None}
+            'oidc_states': {'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()}}
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -213,7 +215,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         url = reverse('oidc_authentication_callback')
         request = self.factory.get(url, get_data)
         request.session = {
-            'oidc_states': {'example_state': 'example_nonce'},
+            'oidc_states': {'example_state': {'nonce': 'example_nonce', 'added_on': datetime.now().timestamp()}},
             'oidc_nonce': 'example_nonce'
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -241,8 +243,8 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         request = self.factory.get(url, get_data)
         request.session = {
             'oidc_states': {
-                'example_state': None,
-                'example_state2': None,
+                'example_state': {'nonce': None, 'added_on': datetime.now().timestamp()},
+                'example_state2': {'nonce': None, 'added_on': datetime.now().timestamp()},
             }
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()


### PR DESCRIPTION
This merge request allows multiple parallel login sessions.

This MR should fix the issues #303 and #312.


**The problem**
Currently `mozilla-django-oidc` only allows one parallel session to go through the OpenID Connect login flow. The problem is, that the `state` and `nonce` parameters are stored in two session variables.

Here is an example workflow where the user runs into an error:
1. `Tab A` User wants to log in, `state` and `nonce` are set in the user's session and user is redirected to the OIDC Provider.
2. `Tab B` User also wants to log in a second tab (of the same application), e.g. because he restores his browser session after reboot etc. This will generate a new `state` and `nonce` value and overwrite the existing two in the session.
3. `Tab A` User authenticates at the OIDC Provider and is redirected back with the `state` and `nonce` from the first step. As those were overwritten, `mozilla-django-oidc` fails with an error that the `state` does not match. `mozilla-django-oidc` also deletes the `nonce` from the session.
4. `Tab B` User also authenticates against the OIDC Provider, is redirected back with the `state` and `nonce` from step 2. The `state` matches the `state` in the session but the `nonce` was deleted in the 3. step, so the user will get an error as well.

=> The problem is that `state` and `nonce` are stored in two variables and will be overwritten when multiple tabs are used.

**Solution**
I've replaced the two session variables `oidc_state` and `oidc_nonce` with a dictionary `oidc_states`.
This dictionary contains `state` (key) - `nonce` (value) pairs.
Every time the user wants to log in, a new `state` - `nonce` combination will be added to this dictionary without overwriting other values.

When a user comes back from the OIDC Provider, `mozilla-django-oidc` will check for the `state` if there is a valid combination in the `oidc_states` dictionary. If yes it will also check the `nonce` value.

**Drawbacks**
- Previously, when the user came back, the `nonce` value was deleted immediately to avoid using it multiple times. This also happened if no `state` or a wrong `state` was provided. Now we have multiple `state` / `nonce` values, and we first need to identify the correct pair. So if no or a wrong `state` are given, we cannot delete a nonce value. But the `nonce` will be deleted if regularly used during a login and thus, I think this can be accepted from a security perspective.
- The `oidc_states` dictionary in the session can grow over time (e.g. if the user initializes a login session but never ends it). For this reason, I empty the whole dictionary if there are more than 20 `state` / `nonce` combinations. I didn't want to implement an aging mechanism to keep the code as simple as possible. Having more than 20 parallel login session is unlikely (or we can also increase this value) and I think we can also accept a login failure in case this really happens.


I adapted the Unittests and wrote an additional one which adds two `state` / `nonce` combinations (simulates two parallel login sessions), executes one successful login and then checks that the other combination is still left in the `oidc_states` dictionary.