### PR TITLE
Update urls install config for Django 2.0+

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -140,13 +140,16 @@ Add routing to urls.py
 
 Next, edit your ``urls.py`` and add the following:
 
+
 .. code-block:: python
 
-   urlpatterns = patterns(
+   from django.urls import path
+   
+   urlpatterns = [
        # ...
-       url(r'^oidc/', include('mozilla_django_oidc.urls')),
+       path('oidc/', include('mozilla_django_oidc.urls')),
        # ...
-   )
+   ]
 
 
 Enable login and logout functionality in templates


### PR DESCRIPTION
The previous set of docs were constructing `urlpatterns` in Django 1.x style; this changes the docs to reflect docs for Django 2 and above.