### PR TITLE
Fix JWKS handling with same `kid` but different `alg` across JWKs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+1.2.4 (Unreleased)
+==================
+
+* Fix JWKS handling when the same `kid` value is used across JWKs with
+  different `alg` specified
+
 1.2.3 (2020-01-02)
 ===================
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -156,7 +156,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             if jwk['kid'] != smart_text(header.kid):
                 continue
             if 'alg' in jwk and jwk['alg'] != smart_text(header.alg):
-                raise SuspiciousOperation('alg values do not match.')
+                continue
             key = jwk
         if key is None:
             raise SuspiciousOperation('Could not find a valid JWKS.')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -940,6 +940,48 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         self.assertEqual(jwk_key, get_json_mock.json.return_value['keys'][0])
 
     @patch('mozilla_django_oidc.auth.requests')
+    def test_retrieve_matching_jwk_same_kid(self, mock_requests):
+        """Test retrieving valid jwk from a list of keys with the same kid"""
+
+        get_json_mock = Mock()
+        get_json_mock.json.return_value = {
+            "keys": [
+                {
+                    "alg": "RS512",
+                    "kid": "foobar",
+                },
+                {
+                    "alg": "RS384",
+                    "kid": "foobar",
+                },
+                {
+                    "alg": "RS256",
+                    "kid": "foobar",
+                }
+            ]
+        }
+        mock_requests.get.return_value = get_json_mock
+
+        header = force_bytes(json.dumps({'alg': 'RS256', 'typ': 'JWT', 'kid': 'foobar'}))
+        payload = force_bytes(json.dumps({'foo': 'bar'}))
+
+        # Compute signature
+        key = b'mysupersecuretestkey'
+        h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
+        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        h.update(force_bytes(msg))
+        signature = b64encode(h.finalize())
+
+        token = '{}.{}.{}'.format(
+            smart_text(b64encode(header)),
+            smart_text(b64encode(payload)),
+            smart_text(signature)
+        )
+
+        jwk_key = self.backend.retrieve_matching_jwk(force_bytes(token))
+        self.assertEqual(jwk_key, get_json_mock.json.return_value['keys'][2])
+
+    @patch('mozilla_django_oidc.auth.requests')
     def test_retrieve_mismatcing_jwk_alg(self, mock_requests):
         """Test retrieving mismatching jwk alg"""
 
@@ -973,7 +1015,7 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         with self.assertRaises(SuspiciousOperation) as ctx:
             self.backend.retrieve_matching_jwk(force_bytes(token))
 
-        self.assertEqual(ctx.exception.args[0], 'alg values do not match.')
+        self.assertEqual(ctx.exception.args[0], 'Could not find a valid JWKS.')
 
     @patch('mozilla_django_oidc.auth.requests')
     def test_retrieve_mismatcing_jwk_kid(self, mock_requests):


### PR DESCRIPTION
Prior to this change, when a JWKS was delivered with multiple JWK with the same `kid` but different `alg` specified, the `retrieve_matching_jwk` function would only consider the first key in the list where the `kid` matched.  If the `alg` didn't match, an exception would be raised and if there was a valid JWK with the right `alg` (eg later in the list) it would not be considered.

In the JWK spec (https://tools.ietf.org/html/rfc7517#section-4.4), the `alg` value isn't required to be unique -- only to match -- so the check shouldn't raise an exception at this point, but rather continue checking all remaining JWKs.

With this change, an exception is still raised at the end if no valid JWK is found.  Test output was updated and a new test added to ensure the right key is retrieved from a list with multiple matching `kids` (`kid` need not be unique as per [rfc7517](https://tools.ietf.org/html/rfc7517#section-4.5)).

This follows and improves the change at #256 and issue at #247.