### PR TITLE
Add regex patterns to OIDC_EXEMPT_URLS setting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ History
 
 * Fix JWKS handling when the same `kid` value is used across JWKs with
   different `alg` specified
+* Support regex patterns in ``OIDC_EXEMPT_URLS``, to allow exempting session refreshes in
+  ``SessionMiddleware`` for URLs matching the pattern
+  Thanks `@jwhitlock`_
+
+.. _`@jwhitlock`: https://github.com/jwhitlock
 
 1.2.3 (2020-01-02)
 ===================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -77,9 +77,9 @@ of ``mozilla-django-oidc``.
 
    :default: ``[]``
 
-   This is a list of absolute url paths or Django view names. This plus the
-   mozilla-django-oidc urls are exempted from the session renewal by the
-   ``SessionRefresh`` middleware.
+   This is a list of absolute url paths, regular expressions for url paths,  or
+   Django view names. This plus the mozilla-django-oidc urls are exempted from
+   the session renewal by the ``SessionRefresh`` middleware.
 
 .. py:attribute:: OIDC_CREATE_USER
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 
 try:
@@ -231,6 +232,37 @@ class MiddlewareTestCase(TestCase):
             sorted(list(middleware.exempt_urls)),
             [u'/authenticate/', u'/callback/', u'/foo/', u'/logout/']
         )
+
+    def test_is_refreshable_url(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URLS=['mdo_fake_view'])
+    def test_is_not_refreshable_url_exempt_view_name(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URLS=['/mdo_fake_view/'])
+    def test_is_not_refreshable_url_exempt_path(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
+
+    @override_settings(OIDC_EXEMPT_URLS=[re.compile(r'^/mdo_.*_view/$')])
+    def test_is_not_refreshable_url_exempt_pattern(self):
+        request = self.factory.get('/mdo_fake_view/')
+        request.user = self.user
+        request.session = dict()
+        middleware = SessionRefresh()
+        assert not middleware.is_refreshable_url(request)
 
     def test_anonymous(self):
         client = ClientWithUser()


### PR DESCRIPTION
Support regex patterns in ``OIDC_EXEMPT_URLS``, to avoid session renewal for any request path that matches the pattern.

This was discussed as an alternate implementation in PR #310, which was a solution for follow-on work for https://github.com/mozilla-services/socorro/pull/4957. This would be used there as:

```
OIDC_EXEMPT_URLS = [
    # Used by supersearch page as an XHR
    "supersearch:search_fields",  # data-fields-url
    "supersearch:search_results",  # data-results-url
    # Used by bugzilla.js
    "/buginfo/bug",
    # Used by signature report as an XHR
    "signature:signature_summary",  # data-urls-summary
    "signature:signature_reports",  # data-urls-reports
    "signature:signature_bugzilla",  # data-urls-bugzilla
    "signature:signature_comments",  # data-urls-comments
    "signature:signature_correlations",  # data-urls-correlations
    re.compile(r"^/signature/graphs/?P<field>\w+)/$"),  # data-urls-graphs
    re.compile(r"^/signature/aggregation/(?P<aggregation>\w+)/$"),  # data-urls-aggregations
]
```
