### PR TITLE
Update middleware.py to not set oidc_login_next for AJAX 403 redirects

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -88,7 +88,7 @@ class SessionRefresh(MiddlewareMixin):
 
         now = time.time()
 
-        if 'X-Refresh-OIDC-Token' in request.headers:
+        if hasattr(request,'headers') and 'X-Refresh-OIDC-Token' in request.headers:
             request.session['oidc_id_token_expiration'] = now
 
         expiration = request.session.get('oidc_id_token_expiration', 0)

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -86,8 +86,13 @@ class SessionRefresh(MiddlewareMixin):
             LOGGER.debug('request is not refreshable')
             return
 
-        expiration = request.session.get('oidc_id_token_expiration', 0)
         now = time.time()
+
+        if 'X-Refresh-OIDC-Token' in request.headers:
+            request.session['oidc_id_token_expiration'] = now
+
+        expiration = request.session.get('oidc_id_token_expiration', 0)
+
         if expiration > now:
             # The id_token is still valid, so we don't have to do anything.
             LOGGER.debug('id token is still valid (%s > %s)', expiration, now)

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -122,8 +122,6 @@ class SessionRefresh(MiddlewareMixin):
 
         add_state_and_nonce_to_session(request, state, params)
 
-        request.session['oidc_login_next'] = request.get_full_path()
-
         query = urlencode(params)
         redirect_url = '{url}?{query}'.format(url=auth_url, query=query)
         if request.is_ajax():
@@ -138,4 +136,6 @@ class SessionRefresh(MiddlewareMixin):
             response = JsonResponse({'refresh_url': redirect_url}, status=403)
             response['refresh_url'] = redirect_url
             return response
+
+        request.session['oidc_login_next'] = request.get_full_path()
         return HttpResponseRedirect(redirect_url)

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -88,7 +88,7 @@ class SessionRefresh(MiddlewareMixin):
 
         now = time.time()
 
-        if hasattr(request,'headers') and 'X-Refresh-OIDC-Token' in request.headers:
+        if hasattr(request, 'headers') and 'X-Refresh-OIDC-Token' in request.headers:
             request.session['oidc_id_token_expiration'] = now
 
         expiration = request.session.get('oidc_id_token_expiration', 0)


### PR DESCRIPTION
Moved the oidc_login_next to below the AJAX return, this means AJAX requests will be redirected to the LOGIN_REDIRECT_URL instead of the API endpoint that generated the session refresh.

Current behavior is to redirect AJAX 403 responses to the API endpoint, this results in the API endpoint response being displayed in the browser main window.

As noted, redirects with XHR requests are extremely finicky, in most cases a simple 302 redirect results in a CORS denial.  So the only way to get a session refresh is to do a window.location.href redirect, the 403 becomes a "simple" 302 redirect (using CORS terminology for simple vs XHR requests).