### PR TITLE
Fixes #370: Deprecation warnings on Django 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,69 +51,13 @@ jobs:
           root: workspace
           paths:
             - mozilla-django-oidc-dev.tar.gz
-  e2e_test_py2_rs_django111:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py2-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=rs
-          - DJANGO_VERSION=Django>=1.11,<2.0.0
-    <<: *common_steps
-  e2e_test_py3_rs_django111:
+  e2e_test_py3_rs_django220:
     docker:
       - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
         name: testoidcsetup
         environment:
           - TEST_OIDC_ALGO=rs
-          - DJANGO_VERSION=Django>=1.11,<2.0.0
-    <<: *common_steps
-  e2e_test_py3_rs_django200:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=rs
-          - DJANGO_VERSION=Django>=2.0.0,<2.1
-    <<: *common_steps
-  e2e_test_py3_rs_django210:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=rs
-          - DJANGO_VERSION=Django>=2.1.0,<2.2
-    <<: *common_steps
-  e2e_test_py2_hs_django111:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py2-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=hs
-          - DJANGO_VERSION=Django>=1.11,<2.0.0
-    <<: *common_steps
-  e2e_test_py3_hs_django111:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=hs
-          - DJANGO_VERSION=Django>=1.11,<2.0.0
-    <<: *common_steps
-  e2e_test_py3_hs_django200:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=hs
-          - DJANGO_VERSION=Django>=2.0.0,<2.1
-    <<: *common_steps
-  e2e_test_py3_hs_django210:
-    docker:
-      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
-        name: testoidcsetup
-        environment:
-          - TEST_OIDC_ALGO=hs
-          - DJANGO_VERSION=Django>=2.1.0,<2.2
+          - DJANGO_VERSION=Django>=2.2.0,<3.0
     <<: *common_steps
   e2e_test_py3_hs_django220:
     docker:
@@ -123,6 +67,14 @@ jobs:
           - TEST_OIDC_ALGO=hs
           - DJANGO_VERSION=Django>=2.2.0,<3.0
     <<: *common_steps
+  e2e_test_py3_rs_django300:
+    docker:
+      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
+        name: testoidcsetup
+        environment:
+          - TEST_OIDC_ALGO=rs
+          - DJANGO_VERSION=Django>=3.0.0,<3.1
+    <<: *common_steps
   e2e_test_py3_hs_django300:
     docker:
       - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
@@ -131,39 +83,43 @@ jobs:
           - TEST_OIDC_ALGO=hs
           - DJANGO_VERSION=Django>=3.0.0,<3.1
     <<: *common_steps
+  e2e_test_py3_rs_django310:
+    docker:
+      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
+        name: testoidcsetup
+        environment:
+          - TEST_OIDC_ALGO=rs
+          - DJANGO_VERSION=Django>=3.1.0,<3.2
+    <<: *common_steps
+  e2e_test_py3_hs_django310:
+    docker:
+      - image: mozilla/oidc-testprovider:oidc_e2e_setup_py3-latest
+        name: testoidcsetup
+        environment:
+          - TEST_OIDC_ALGO=hs
+          - DJANGO_VERSION=Django>=3.1.0,<3.2
+    <<: *common_steps
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build_lib
-      - e2e_test_py2_rs_django111:
-          requires:
-            - build_lib
-      - e2e_test_py2_hs_django111:
-          requires:
-            - build_lib
-      - e2e_test_py3_rs_django111:
-          requires:
-            - build_lib
-      - e2e_test_py3_hs_django111:
-          requires:
-            - build_lib
-      - e2e_test_py3_rs_django200:
-          requires:
-            - build_lib
-      - e2e_test_py3_hs_django200:
-          requires:
-            - build_lib
-      - e2e_test_py3_rs_django210:
-          requires:
-            - build_lib
-      - e2e_test_py3_hs_django210:
+      - e2e_test_py3_rs_django220:
           requires:
             - build_lib
       - e2e_test_py3_hs_django220:
           requires:
             - build_lib
+      - e2e_test_py3_rs_django300:
+          requires:
+            - build_lib
       - e2e_test_py3_hs_django300:
+          requires:
+            - build_lib
+      - e2e_test_py3_rs_django310:
+          requires:
+            - build_lib
+      - e2e_test_py3_hs_django310:
           requires:
             - build_lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ sudo: false
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install codecov tox-travis
@@ -27,5 +27,5 @@ deploy:
     on:
       repo: mozilla/mozilla-django-oidc
       tags: true
-      python: '3.6'
+      python: '3.9'
     distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 language: python
 
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import SuspiciousOperation, ImproperlyConfigured
 from django.urls import reverse
-from django.utils.encoding import force_bytes, smart_text, smart_bytes
+from django.utils.encoding import force_bytes, smart_str, smart_bytes
 from django.utils.module_loading import import_string
 
 from josepy.b64 import b64decode
@@ -38,7 +38,7 @@ def default_username_algo(email):
         hashlib.sha1(force_bytes(email)).digest()
     ).rstrip(b'=')
 
-    return smart_text(username)
+    return smart_str(username)
 
 
 class OIDCAuthenticationBackend(ModelBackend):
@@ -159,9 +159,9 @@ class OIDCAuthenticationBackend(ModelBackend):
         key = None
         for jwk in jwks['keys']:
             if (import_from_settings("OIDC_VERIFY_KID", True)
-                    and jwk['kid'] != smart_text(header.kid)):
+                    and jwk['kid'] != smart_str(header.kid)):
                 continue
-            if 'alg' in jwk and jwk['alg'] != smart_text(header.alg):
+            if 'alg' in jwk and jwk['alg'] != smart_str(header.alg):
                 continue
             key = jwk
         if key is None:
@@ -172,7 +172,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         """Helper method to get the payload of the JWT token."""
         if self.get_settings('OIDC_ALLOW_UNSECURED_JWT', False):
             header, payload_data, signature = token.split(b'.')
-            header = json.loads(smart_text(b64decode(header)))
+            header = json.loads(smart_str(b64decode(header)))
 
             # If config allows unsecured JWTs check the header and return the decoded payload
             if 'alg' in header and header['alg'] == 'none':

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -162,7 +162,7 @@ class SessionRefresh(MiddlewareMixin):
 
         query = urlencode(params)
         redirect_url = '{url}?{query}'.format(url=auth_url, query=query)
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             # Almost all XHR request handling in client-side code struggles
             # with redirects since redirecting to a page where the user
             # is supposed to do something is extremely unlikely to work

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -14,11 +14,7 @@ from mozilla_django_oidc.utils import (absolutify,
                                        add_state_and_nonce_to_session,
                                        import_from_settings)
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    # Python < 3
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 try:
     # Python 3.7 or later

--- a/mozilla_django_oidc/urls.py
+++ b/mozilla_django_oidc/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.utils.module_loading import import_string
 
 from mozilla_django_oidc import views
@@ -18,9 +18,9 @@ AUTHENTICATE_CLASS_PATH = import_from_settings(
 OIDCAuthenticateClass = import_string(AUTHENTICATE_CLASS_PATH)
 
 urlpatterns = [
-    url(r'^callback/$', OIDCCallbackClass.as_view(),
+    path('callback/', OIDCCallbackClass.as_view(),
         name='oidc_authentication_callback'),
-    url(r'^authenticate/$', OIDCAuthenticateClass.as_view(),
+    path('authenticate/', OIDCAuthenticateClass.as_view(),
         name='oidc_authentication_init'),
-    url(r'^logout/$', views.OIDCLogoutView.as_view(), name='oidc_logout'),
+    path('logout/', views.OIDCLogoutView.as_view(), name='oidc_logout'),
 ]

--- a/mozilla_django_oidc/urls.py
+++ b/mozilla_django_oidc/urls.py
@@ -18,9 +18,7 @@ AUTHENTICATE_CLASS_PATH = import_from_settings(
 OIDCAuthenticateClass = import_string(AUTHENTICATE_CLASS_PATH)
 
 urlpatterns = [
-    path('callback/', OIDCCallbackClass.as_view(),
-        name='oidc_authentication_callback'),
-    path('authenticate/', OIDCAuthenticateClass.as_view(),
-        name='oidc_authentication_init'),
+    path('callback/', OIDCCallbackClass.as_view(), name='oidc_authentication_callback'),
+    path('authenticate/', OIDCAuthenticateClass.as_view(), name='oidc_authentication_init'),
     path('logout/', views.OIDCLogoutView.as_view(), name='oidc_logout'),
 ]

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -5,11 +5,7 @@ import warnings
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-try:
-    from urllib.request import parse_http_list, parse_keqv_list
-except ImportError:
-    # python < 3
-    from urllib2 import parse_http_list, parse_keqv_list
+from urllib.request import parse_http_list, parse_keqv_list
 
 
 LOGGER = logging.getLogger(__name__)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -19,11 +19,7 @@ from mozilla_django_oidc.utils import (absolutify,
                                        add_state_and_nonce_to_session,
                                        import_from_settings)
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    # Python < 3
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 
 class OIDCAuthenticationCallbackView(View):

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -8,7 +8,7 @@ from django.utils.crypto import get_random_string
 
 try:
     from django.utils.http import url_has_allowed_host_and_scheme
-except:
+except ImportError:
     # Django <= 2.2
     from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -5,7 +5,13 @@ from django.core.exceptions import SuspiciousOperation
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.crypto import get_random_string
-from django.utils.http import is_safe_url
+
+try:
+    from django.utils.http import url_has_allowed_host_and_scheme
+except:
+    # Django <= 2.2
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+
 from django.utils.module_loading import import_string
 from django.views.generic import View
 
@@ -127,7 +133,7 @@ def get_next_url(request, redirect_field_name):
         hosts.append(request.get_host())
         kwargs['allowed_hosts'] = hosts
 
-        is_safe = is_safe_url(**kwargs)
+        is_safe = url_has_allowed_host_and_scheme(**kwargs)
         if is_safe:
             return next_url
     return None

--- a/tests/namespaced_urls.py
+++ b/tests/namespaced_urls.py
@@ -1,3 +1,3 @@
-from django.conf.urls import url, include
+from django.urls import path, include
 
-urlpatterns = [url(r'^namespace/', include(('mozilla_django_oidc.urls', 'namespace')))]
+urlpatterns = [path('namespace/', include(('mozilla_django_oidc.urls', 'namespace')))]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.test import RequestFactory, TestCase, override_settings
-from django.utils.encoding import force_bytes, smart_text
+from django.utils.encoding import force_bytes, smart_str
 
 from mozilla_django_oidc.auth import (
     default_username_algo,
@@ -86,8 +86,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         payload = force_bytes(json.dumps({'foo': 'bar'}))
         signature = ''
         token = force_bytes('{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
             signature
         ))
 
@@ -101,8 +101,8 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         payload = force_bytes(json.dumps({'foo': 'bar'}))
         signature = ''
         token = force_bytes('{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
             signature
         ))
 
@@ -118,17 +118,17 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
         token_bytes = force_bytes(token)
-        key_text = smart_text(key)
+        key_text = smart_str(key)
         output = self.backend.get_payload_data(token_bytes, key_text)
         self.assertEqual(output, payload)
 
@@ -141,17 +141,17 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
         token_bytes = force_bytes(token)
-        key_text = smart_text(key)
+        key_text = smart_str(key)
         output = self.backend.get_payload_data(token_bytes, key_text)
         self.assertEqual(output, payload)
 
@@ -165,17 +165,17 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         key = b'mysupersecuretestkey'
         fake_key = b'mysupersecurefaketestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
         token_bytes = force_bytes(token)
-        key_text = smart_text(fake_key)
+        key_text = smart_str(fake_key)
 
         with self.assertRaises(SuspiciousOperation) as ctx:
             self.backend.get_payload_data(token_bytes, key_text)
@@ -191,17 +191,17 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         key = b'mysupersecuretestkey'
         fake_key = b'mysupersecurefaketestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
         token_bytes = force_bytes(token)
-        key_text = smart_text(fake_key)
+        key_text = smart_str(fake_key)
 
         with self.assertRaises(SuspiciousOperation) as ctx:
             self.backend.get_payload_data(token_bytes, key_text)
@@ -948,14 +948,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         jwk_key = self.backend.retrieve_matching_jwk(force_bytes(token))
@@ -990,14 +990,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         jwk_key = self.backend.retrieve_matching_jwk(force_bytes(token))
@@ -1024,14 +1024,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         with self.assertRaises(SuspiciousOperation) as ctx:
@@ -1060,14 +1060,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         with self.assertRaises(SuspiciousOperation) as ctx:
@@ -1095,14 +1095,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         jwk_key = self.backend.retrieve_matching_jwk(force_bytes(token))
@@ -1129,14 +1129,14 @@ class OIDCAuthenticationBackendRS256WithJwksEndpointTestCase(TestCase):
         # Compute signature
         key = b'mysupersecuretestkey'
         h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
-        msg = '{}.{}'.format(smart_text(b64encode(header)), smart_text(b64encode(payload)))
+        msg = '{}.{}'.format(smart_str(b64encode(header)), smart_str(b64encode(payload)))
         h.update(force_bytes(msg))
         signature = b64encode(h.finalize())
 
         token = '{}.{}.{}'.format(
-            smart_text(b64encode(header)),
-            smart_text(b64encode(payload)),
-            smart_text(signature)
+            smart_str(b64encode(header)),
+            smart_str(b64encode(payload)),
+            smart_str(signature)
         )
 
         with self.assertRaises(SuspiciousOperation) as ctx:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from mock import patch
 
-from django.conf.urls import url
+from django.urls import path
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_out
 from django.contrib.auth.models import AnonymousUser
@@ -143,7 +143,7 @@ def fakeview(req):
 
 
 urlpatterns = list(orig_urlpatterns) + [
-    url(r'^mdo_fake_view/$', fakeview, name='mdo_fake_view')
+    path('mdo_fake_view/', fakeview, name='mdo_fake_view')
 ]
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,11 +2,7 @@ import json
 import re
 import time
 
-try:
-    from urllib.parse import parse_qs
-except ImportError:
-    # Python < 3
-    from urlparse import parse_qs
+from urllib.parse import parse_qs
 
 from mock import patch
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,10 +1,6 @@
 import time
 
-try:
-    from urllib.parse import parse_qs, urlparse
-except ImportError:
-    # Python < 3
-    from urlparse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse
 
 from mock import patch
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -297,7 +297,7 @@ class GetNextURLTestCase(TestCase):
     def test_bad_urls(self):
         urls = [
             '',
-            # NOTE(willkg): Test data taken from the Django is_safe_url tests.
+            # NOTE(willkg): Test data taken from the Django url_has_allowed_host_and_scheme tests.
             'http://example.com',
             'http:///example.com',
             'https://example.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 envlist =
     lint
-    py{35,36,37,38}-django220
-    py{36,37,38}-django300
-    py{36,37,38}-django310
+    py{36,37,38,39}-django220
+    py{36,37,38,39}-django300
+    py{36,37,38,39}-django310
 
 [travis]
 python =
-  3.5: py35
   3.6: py36
   3.7: py37
-  3.8: py38, coverage, lint
+  3.8: py38
+  3.9: py39, coverage, lint
 
 [testenv]
 commands = django-admin.py test
@@ -33,8 +33,8 @@ commands =
 deps =
     coverage
     -r{toxinidir}/tests/requirements.txt
-    Django>=2.2
-    djangorestframework>=3.7
+    Django>=3.1
+    djangorestframework>=3.9
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,16 @@
 [tox]
 envlist =
     lint
-    py{27,34,35,36}-django111
-    py{34,35,36,37}-django200
-    py{35,36,37}-django210
-    py{35,36,37}-django220
+    py{35,36,37,38}-django220
     py{36,37,38}-django300
+    py{36,37,38}-django310
 
 [travis]
 python =
-  2.7: py27
-  3.4: py34
   3.5: py35
   3.6: py36
-  3.7: py37, coverage, lint
-  3.8: py38
+  3.7: py37
+  3.8: py38, coverage, lint
 
 [testenv]
 commands = django-admin.py test
@@ -24,15 +20,11 @@ setenv =
     PYTHONWARNINGS=default
 deps =
     -r{toxinidir}/tests/requirements.txt
-    django111: Django>=1.11,<2.0.0
-    django111: djangorestframework>=3.4
-    django200: Django>=2.0.0,<2.1
-    django200: djangorestframework>=3.7
-    django210: Django>=2.1.0,<2.2
-    django210: djangorestframework>=3.7
     django220: Django>=2.2.0,<3.0
     django220: djangorestframework>=3.7
     django300: Django>=3.0.0,<3.1
+    django300: djangorestframework>=3.7
+    django300: Django>=3.1.0,<3.2
     django300: djangorestframework>=3.7
 
 [testenv:coverage]
@@ -41,8 +33,8 @@ commands =
 deps =
     coverage
     -r{toxinidir}/tests/requirements.txt
-    Django>=1.11
-    djangorestframework>=3.4
+    Django>=2.2
+    djangorestframework>=3.7
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ deps =
     django220: djangorestframework>=3.7
     django300: Django>=3.0.0,<3.1
     django300: djangorestframework>=3.7
-    django300: Django>=3.1.0,<3.2
-    django300: djangorestframework>=3.7
+    django310: Django>=3.1.0,<3.2
+    django310: djangorestframework>=3.7
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
Since Django 1.11, which is the last version not supporting the new path syntax is not supported anymore, there should be no blockers merging this.
Btw: I found some import try/except blocks for python2/3 - if python2 is unsupported, should those be removed?