### PR TITLE
#369: Update middleware init to configure settings

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -39,6 +39,18 @@ class SessionRefresh(MiddlewareMixin):
 
     """
 
+    def __init__(self, *args, **kwargs):
+        super(SessionRefresh, self).__init__(*args, **kwargs)
+        self.OIDC_EXEMPT_URLS = self.get_settings('OIDC_EXEMPT_URLS', [])
+        self.OIDC_OP_AUTHORIZATION_ENDPOINT = self.get_settings('OIDC_OP_AUTHORIZATION_ENDPOINT')
+        self.OIDC_RP_CLIENT_ID = self.get_settings('OIDC_RP_CLIENT_ID')
+        self.OIDC_STATE_SIZE = self.get_settings('OIDC_STATE_SIZE', 32)
+        self.OIDC_AUTHENTICATION_CALLBACK_URL = self.get_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
+                                                                  'oidc_authentication_callback')
+        self.OIDC_RP_SCOPES = self.get_settings('OIDC_RP_SCOPES', 'openid email')
+        self.OIDC_USE_NONCE = self.get_settings('OIDC_USE_NONCE', True)
+        self.OIDC_NONCE_SIZE = self.get_settings('OIDC_NONCE_SIZE', 32)
+
     @staticmethod
     def get_settings(attr, *args):
         return import_from_settings(attr, *args)
@@ -55,7 +67,7 @@ class SessionRefresh(MiddlewareMixin):
 
         """
         exempt_urls = []
-        for url in self.get_settings('OIDC_EXEMPT_URLS', []):
+        for url in self.OIDC_EXEMPT_URLS:
             if not isinstance(url, re_Pattern):
                 exempt_urls.append(url)
         exempt_urls.extend([
@@ -80,7 +92,7 @@ class SessionRefresh(MiddlewareMixin):
             ``re.compile(r"/user/[0-9]+/image")``)
         """
         exempt_patterns = set()
-        for url_pattern in self.get_settings('OIDC_EXEMPT_URLS', []):
+        for url_pattern in self.OIDC_EXEMPT_URLS:
             if isinstance(url_pattern, re_Pattern):
                 exempt_patterns.add(url_pattern)
         return exempt_patterns
@@ -122,9 +134,9 @@ class SessionRefresh(MiddlewareMixin):
 
         LOGGER.debug('id token has expired')
         # The id_token has expired, so we have to re-authenticate silently.
-        auth_url = self.get_settings('OIDC_OP_AUTHORIZATION_ENDPOINT')
-        client_id = self.get_settings('OIDC_RP_CLIENT_ID')
-        state = get_random_string(self.get_settings('OIDC_STATE_SIZE', 32))
+        auth_url = self.OIDC_OP_AUTHORIZATION_ENDPOINT
+        client_id = self.OIDC_RP_CLIENT_ID
+        state = get_random_string(self.OIDC_STATE_SIZE)
 
         # Build the parameters as if we were doing a real auth handoff, except
         # we also include prompt=none.
@@ -133,16 +145,15 @@ class SessionRefresh(MiddlewareMixin):
             'client_id': client_id,
             'redirect_uri': absolutify(
                 request,
-                reverse(self.get_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
-                                          'oidc_authentication_callback'))
+                reverse(self.OIDC_AUTHENTICATION_CALLBACK_URL)
             ),
             'state': state,
-            'scope': self.get_settings('OIDC_RP_SCOPES', 'openid email'),
+            'scope': self.OIDC_RP_SCOPES,
             'prompt': 'none',
         }
 
-        if self.get_settings('OIDC_USE_NONCE', True):
-            nonce = get_random_string(self.get_settings('OIDC_NONCE_SIZE', 32))
+        if self.OIDC_USE_NONCE:
+            nonce = get_random_string(self.OIDC_NONCE_SIZE)
             params.update({
                 'nonce': nonce
             })

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -45,8 +45,10 @@ class SessionRefresh(MiddlewareMixin):
         self.OIDC_OP_AUTHORIZATION_ENDPOINT = self.get_settings('OIDC_OP_AUTHORIZATION_ENDPOINT')
         self.OIDC_RP_CLIENT_ID = self.get_settings('OIDC_RP_CLIENT_ID')
         self.OIDC_STATE_SIZE = self.get_settings('OIDC_STATE_SIZE', 32)
-        self.OIDC_AUTHENTICATION_CALLBACK_URL = self.get_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
-                                                                  'oidc_authentication_callback')
+        self.OIDC_AUTHENTICATION_CALLBACK_URL = self.get_settings(
+            'OIDC_AUTHENTICATION_CALLBACK_URL',
+            'oidc_authentication_callback',
+        )
         self.OIDC_RP_SCOPES = self.get_settings('OIDC_RP_SCOPES', 'openid email')
         self.OIDC_USE_NONCE = self.get_settings('OIDC_USE_NONCE', True)
         self.OIDC_NONCE_SIZE = self.get_settings('OIDC_NONCE_SIZE', 32)


### PR DESCRIPTION
As discussed over on #369 - I've made the middleware class settings discovery to be done in the `__init__` method similarly to `OIDCAuthenticationBackend`

Also updated the overridden settings on the middleware test because the are required for anything accessing the middleware now