### PR TITLE
Verify user_can_authenticate when authenticating user

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 pending
 =======
 
+Backwards-incompatible changes:
+
+* ``OIDCAuthenticationBackend.authenticate`` now calls ``user_can_authenticate``.
+
+Minor:
+
 * Make `get_or_create_user` compatible with custom scope configuration
   by moving scope specific code to `describe_user_by_claims`
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -319,7 +319,8 @@ class OIDCAuthenticationBackend(ModelBackend):
         users = self.filter_users_by_claims(user_info)
 
         if len(users) == 1:
-            return self.update_user(users[0], user_info)
+            user = self.update_user(users[0], user_info)
+            return user if self.user_can_authenticate(user) else None
         elif len(users) > 1:
             # In the rare case that two user accounts have the same email address,
             # bail. Randomly selecting one seems really wrong.
@@ -327,7 +328,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             raise SuspiciousOperation(msg)
         elif self.get_settings('OIDC_CREATE_USER', True):
             user = self.create_user(user_info)
-            return user
+            return user if self.user_can_authenticate(user) else None
         else:
             LOGGER.debug('Login failed: No user with %s found, and '
                          'OIDC_CREATE_USER is False',


### PR DESCRIPTION
The standard Django `ModelBackend` only returns a user from  `authenticate`
if `user_can_authenticate` is `True`.

The `OIDCAuthenticationBackend` doesn't check `user_can_authenticate`,
in its `authenticate` method, allowing a user to log-in that has `is_active`
set to `False`.

This behavior is a surprising deviation from the way `ModelBackend`
works.

It can lead to security problems because other important
authentication checks may inadvertently be bypassed, if the user
implements them in `user_can_authenticate`, expecting
`OIDCAuthenticationBackend` to call it the same as any other
`ModelBackend`.

It seems proper for the `OIDCAuthenticationBackend` to verify
`user_can_authenticate` and it seems to me like there are no problems
associated with doing so, so let's just call `user_can_authenticate`
to resolve the problems described above.