### PR TITLE
tests: Check for None with assertIsNone

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -54,7 +54,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
     def test_missing_request_arg(self):
         """Test authentication returns `None` when `request` is not provided."""
-        self.assertEqual(self.backend.authenticate(request=None), None)
+        self.assertIsNone(self.backend.authenticate(request=None))
 
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.verify_token')
     @patch('mozilla_django_oidc.auth.requests')
@@ -77,7 +77,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'accesss_token': 'access_token'
         }
         request_mock.post.return_value = post_json_mock
-        self.assertEqual(self.backend.authenticate(request=auth_request), None)
+        self.assertIsNone(self.backend.authenticate(request=auth_request))
 
     @override_settings(OIDC_ALLOW_UNSECURED_JWT=True)
     def test_allowed_unsecured_token(self):
@@ -216,7 +216,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
     def test_get_invalid_user(self):
         """Test get_user method with non existing user."""
 
-        self.assertEqual(self.backend.get_user(user_id=1), None)
+        self.assertIsNone(self.backend.get_user(user_id=1))
 
     @override_settings(ROOT_URLCONF='tests.namespaced_urls')
     @override_settings(OIDC_AUTHENTICATION_CALLBACK_URL='namespace:oidc_authentication_callback')
@@ -644,7 +644,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_granted'
         }
         request_mock.post.return_value = post_json_mock
-        self.assertEqual(self.backend.authenticate(request=auth_request), None)
+        self.assertIsNone(self.backend.authenticate(request=auth_request))
 
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
     @patch('mozilla_django_oidc.auth.requests')
@@ -759,7 +759,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_granted'
         }
         request_mock.post.return_value = post_json_mock
-        self.assertEqual(self.backend.authenticate(request=auth_request), None)
+        self.assertIsNone(self.backend.authenticate(request=auth_request))
 
     @override_settings(OIDC_USE_NONCE=False)
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend._verify_jws')
@@ -787,7 +787,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_granted'
         }
         request_mock.post.return_value = post_json_mock
-        self.assertEqual(self.backend.authenticate(request=auth_request), None)
+        self.assertIsNone(self.backend.authenticate(request=auth_request))
 
     @override_settings(OIDC_USE_NONCE=False)
     @patch('mozilla_django_oidc.auth.OIDCAuthenticationBackend.update_user')
@@ -822,7 +822,7 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             'access_token': 'access_granted'
         }
         request_mock.post.return_value = post_json_mock
-        self.assertEqual(self.backend.authenticate(request=auth_request), None)
+        self.assertIsNone(self.backend.authenticate(request=auth_request))
 
         self.assertEqual(User.objects.get().first_name, 'a_username')
 

--- a/tests/test_contrib_drf.py
+++ b/tests/test_contrib_drf.py
@@ -19,7 +19,7 @@ class TestDRF(TestCase):
     def test_authenticate_returns_none_if_no_access_token(self):
         with mock.patch.object(self.auth, 'get_access_token', return_value=None):
             ret = self.auth.authenticate(self.request)
-        self.assertEqual(ret, None)
+        self.assertIsNone(ret)
 
     def test_authenticate_raises_authenticationfailed_if_backend_returns_no_user(self):
         self.auth.backend.get_or_create_user.return_value = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,7 +122,7 @@ class SessionStateTestCase(TestCase):
         self.assertTrue(isinstance(self.request.session['oidc_states'][state], dict))
 
         # Test nonce
-        self.assertEqual(self.request.session['oidc_states'][state]['nonce'], None)
+        self.assertIsNone(self.request.session['oidc_states'][state]['nonce'])
 
         # Test added_on timestamp
         self.assertTrue(isinstance(self.request.session['oidc_states'][state]['added_on'], float))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -274,7 +274,7 @@ class GetNextURLTestCase(TestCase):
     def test_no_param(self):
         req = self.factory.get('/')
         next_url = views.get_next_url(req, 'next')
-        self.assertEqual(next_url, None)
+        self.assertIsNone(next_url)
 
     def test_non_next_param(self):
         req = self.factory.get('/', data={'redirectto': '/foo'})
@@ -331,7 +331,7 @@ class GetNextURLTestCase(TestCase):
             req = self.build_request(next_url=url)
             next_url = views.get_next_url(req, 'next')
 
-            self.assertEqual(next_url, None)
+            self.assertIsNone(next_url)
 
     def test_https(self):
         # If the request is for HTTPS and the next url is HTTPS, then that
@@ -353,7 +353,7 @@ class GetNextURLTestCase(TestCase):
         )
         self.assertEqual(req.is_secure(), True)
         next_url = views.get_next_url(req, 'next')
-        self.assertEqual(next_url, None)
+        self.assertIsNone(next_url)
 
     @override_settings(OIDC_REDIRECT_REQUIRE_HTTPS=False)
     def test_redirect_https_not_required(self):


### PR DESCRIPTION
Comporisons with None should always use the identity operator, not the
equality operator