### PR TITLE
Users filter in docs should return collection

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -255,7 +255,7 @@ email address. Then we could do this:
 
            try:
                profile = Profile.objects.get(email=email)
-               return profile.user
+               return [profile.user]
 
            except Profile.DoesNotExist:
                return self.UserModel.objects.none()


### PR DESCRIPTION
The method `filter_users_by_claim()` should return an object that supports `len()`. The previous example in the documentation returned the user object directly. Wrapping the user in a list fixes the issue.

This is not an issues with the actual code. This PR fixes the example on how to override the user matching in the documentation.