### PR TITLE
Do not fail if JWK doesn't include key id

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -159,7 +159,7 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         key = None
         for jwk in jwks['keys']:
-            if jwk['kid'] != smart_text(header.kid):
+            if 'kid' in jwk and jwk['kid'] != smart_text(header.kid):
                 continue
             if 'alg' in jwk and jwk['alg'] != smart_text(header.alg):
                 continue


### PR DESCRIPTION
Section 4.5 of RFC 7517 states: "Use of [kid] is OPTIONAL".

The current code assumes that `kid` is always provided.

This is not always the case, for example the OIDC implementation of
SATOSA does not provide `kid`.

This case should be handled gracefully instead of causing a
`KeyErrror`.

Fixes: #375