### PR TITLE
Handle case that error_description is not included in www-authenticate header

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,8 @@ pending
 
 * Make `get_or_create_user` compatible with custom scope configuration
   by moving scope specific code to `describe_user_by_claims`
-
+* Fix bug in contrib.drf.OIDCAuthentication where `error_description` is assumed to
+  be present in `www-authenticate` header despite it being optional in the spec
 1.2.4 (2020-08-19)
 ==================
 

--- a/mozilla_django_oidc/contrib/drf.py
+++ b/mozilla_django_oidc/contrib/drf.py
@@ -79,7 +79,7 @@ class OIDCAuthentication(authentication.BaseAuthentication):
             # we can get from the www-authentication header) in the response.
             if resp.status_code == 401 and 'www-authenticate' in resp.headers:
                 data = parse_www_authenticate_header(resp.headers['www-authenticate'])
-                raise exceptions.AuthenticationFailed(data['error_description'])
+                raise exceptions.AuthenticationFailed(data.get('error_description'))
 
             # for all other http errors, just re-raise the exception.
             raise


### PR DESCRIPTION
In the case that an OIDC provider returns 401, a www-authenticate header is included. The code breaks if the error_description field is not present in the www-authenticate header, but [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3) says:
>In addition, the resource server MAY include the "error_description" attribute to provide developers a human-readable explanation that is not meant to be displayed to end-users. 