### PR TITLE
add setting which adds the response from the token endpoint to a user's claims

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+next release
+============
+
+* Add `OIDC_ADD_TOKEN_INFO_TO_USER_CLAIMS` setting which adds the response
+  from the token endpoint to a user's claims
+
 2.0.0 (2021-07-27)
 ==================
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -263,3 +263,10 @@ of ``mozilla-django-oidc``.
    :default: False
 
    Allow using GET method to logout user
+
+.. py:attribute:: OIDC_ADD_TOKEN_INFO_TO_USER_CLAIMS
+
+   :default: False
+
+   Add the response from the token endpoint to the user's claims under the "token_info" key.
+   Useful for storing an access_token or refresh_token in your User model.


### PR DESCRIPTION
useful/necessary for storing a refresh_token in a User model