### PR TITLE
Update settings.rst

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -172,7 +172,6 @@ of ``mozilla-django-oidc``.
    :default: ``False``
 
    Controls whether the OpenID Connect client stores the OIDC ``id_token`` in the user session.
-   The session key used to store the data is ``oidc_id_token``.
 
 .. py:attribute:: OIDC_AUTH_REQUEST_EXTRA_PARAMS
 


### PR DESCRIPTION
If this is older information, it might be good to remove it. Skimmers (read me) might only see the last sentence and not read carefully enough to not use oidc_id_token as the session key on the first go round.