### PR TITLE
Remove state from session for failed authentication attempts

### DIFF
--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -60,6 +60,15 @@ class OIDCAuthenticationCallbackView(View):
 
         if request.GET.get('error'):
             # Ouch! Something important failed.
+
+            # Delete the state entry also for failed authentication attempts
+            # to prevent replay attacks.
+            if ('state' in request.GET
+                    and 'oidc_states' in request.session
+                    and request.GET['state'] in request.session['oidc_states']):
+                del request.session['oidc_states'][request.GET['state']]
+                request.session.save()
+
             # Make sure the user doesn't get to continue to be logged in
             # otherwise the refresh middleware will force the user to
             # redirect to authorize again if the session refresh has


### PR DESCRIPTION
When authentication succeeds, we remove the state from the users
session to prevent replay attacks.

We should do the same when the auth provider presents us with an
error message.