### PR TITLE
Track login next URL as part of OIDC state

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -156,9 +156,7 @@ class SessionRefresh(MiddlewareMixin):
                 'nonce': nonce
             })
 
-        add_state_and_nonce_to_session(request, state, params)
-
-        request.session['oidc_login_next'] = request.get_full_path()
+        add_state_and_nonce_to_session(request, state, params, next=request.get_full_path())
 
         query = urlencode(params, quote_via=quote)
         redirect_url = '{url}?{query}'.format(url=auth_url, query=query)

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -54,7 +54,7 @@ def is_authenticated(user):
     return user.is_authenticated
 
 
-def add_state_and_nonce_to_session(request, state, params):
+def add_state_and_nonce_to_session(request, state, params, next=None):
     """
     Stores the `state` and `nonce` parameters in a session dictionary including the time when it
     was added. The dictionary can contain multiple state/nonce combinations to allow parallel
@@ -97,3 +97,6 @@ def add_state_and_nonce_to_session(request, state, params):
         'nonce': nonce,
         'added_on': time.time(),
     }
+
+    if next is not None:
+        request.session['oidc_states'][state]['next'] = next


### PR DESCRIPTION
We support multiple parallel login processes by using a dictionary
for `oidc_state`.

With only a single shared `oidc_login_next` field in the session,
all login processes will redirect the user to the next URL set by
the login process they initiated last.

This behavior seems confusing and not that useful.

By storing the login next URL as part of the state, we can have each
login process redirect to the next URL provided at its initiation.

Also, we get the benefit that the login next URL for that login process
will not be lingering around in the session anymore, as the whole state
for that login process, including the login next URL, will be removed by
the OIDC callback.