### PR TITLE
fix: add missing extra params to SessionRefresh

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -150,6 +150,8 @@ class SessionRefresh(MiddlewareMixin):
             'prompt': 'none',
         }
 
+        params.update(self.get_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {}))
+
         if self.OIDC_USE_NONCE:
             nonce = get_random_string(self.OIDC_NONCE_SIZE)
             params.update({


### PR DESCRIPTION
otherwise refreshing authentication is missing the extra params that the first authentication has (in the View)