### PR TITLE
Adds variable extra_params from callback

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -180,6 +180,24 @@ of ``mozilla-django-oidc``.
 
    Additional parameters to include in the initial authorization request.
 
+.. py:attribute:: OIDC_AUTH_REQUEST_EXTRA_PARAMS_FUNC
+
+   :default: `None`
+
+   Import string of a function that accepts a Django ``request`` and returns a ``Dict`` containing
+   additonal parameters to include in the initial authorization request.
+
+   .. code-block:: python
+
+      def get_extra_params(request):
+          return {
+             'my_extra_param': 'custom_value'
+          }
+
+   .. warning::
+
+   This feature may override values set in the ``OIDC_AUTH_REQUEST_EXTRA_PARAMS`` setting on matching keys.
+
 .. py:attribute:: OIDC_RP_SIGN_ALGO
 
    :default: ``HS256``

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -194,7 +194,12 @@ class OIDCAuthenticationRequestView(View):
         return HttpResponseRedirect(redirect_url)
 
     def get_extra_params(self, request):
-        return self.get_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})
+        params = self.get_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})
+        f_str = self.get_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS_FUNC', None)
+        if f_str:
+            f = import_string(f_str)
+            params.update(f(request))
+        return params
 
 
 class OIDCLogoutView(View):


### PR DESCRIPTION
fixes: https://github.com/mozilla/mozilla-django-oidc/issues/450

Allows implementers to customize extra_params in the authorization request based attributes from the `request` object.  This is useful in cases where IDPs expect additional querystring params in their `/authorize` APIs that are user-specific, instead of adding the same `OIDC_AUTH_REQUEST_EXTRA_PARAMS` on every request.

I added a test and updated the docs, please let me know what else I need to do!