### PR TITLE
Handle when error_description isn't present in www-authenticate header

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+pending
+=======
+* Fix bug in ``contrib.drf.OIDCAuthentication`` where ``error_description`` is assumed to be present in ``www-authenticate`` header despite it being optional in the spec.
+
 2.0.0 (2021-07-27)
 ==================
 

--- a/mozilla_django_oidc/contrib/drf.py
+++ b/mozilla_django_oidc/contrib/drf.py
@@ -86,7 +86,7 @@ class OIDCAuthentication(authentication.BaseAuthentication):
             # we can get from the www-authentication header) in the response.
             if resp.status_code == 401 and "www-authenticate" in resp.headers:
                 data = parse_www_authenticate_header(resp.headers["www-authenticate"])
-                raise exceptions.AuthenticationFailed(data["error_description"])
+                raise exceptions.AuthenticationFailed(data.get("error_description", "no error description in www-authenticate"))
 
             # for all other http errors, just re-raise the exception.
             raise


### PR DESCRIPTION
In the case that an OIDC provider returns 401, a www-authenticate header is included. The code breaks if the error_description field is not present in the www-authenticate header, but [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3) says:

In addition, the resource server MAY include the "error_description" attribute to provide developers a human-readable explanation that is not meant to be displayed to end-users.

This is the same as the PR: https://github.com/mozilla/mozilla-django-oidc/pull/420
I dont think that PR is going to be updated so created a new PR to move it to completion