### PR TITLE
Support PKCE

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+
+pending
+=======
+
+* Added PKCE support in the authorization code flow.
+
+
 3.0.0 (2022-11-14)
 ==================
 * Gracefully handle ``www-authenticate`` header with missing ``error_description``.
@@ -65,7 +72,7 @@ Backwards-incompatible changes:
   ``SessionMiddleware`` for URLs matching the pattern
   Thanks `@jwhitlock <https://github.com/jwhitlock>`_
 * Move nonce outside of add_state_and_noce_to_session method.
-* Change log level to info for the add_state_and_nonce_to_session.
+* Change log level to info for the add_state_and_verifier_and_nonce_to_session.
 * Session save/load management
   Thanks `@Flor1an-dev <https://github.com/Flor1an-dev>`_
 * Allow multiple parallel login sessions

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -271,3 +271,50 @@ of ``mozilla-django-oidc``.
    :default: False
 
    Allow using GET method to logout user
+
+.. py:attribute:: OIDC_USE_PKCE
+
+   :default: ``True``
+
+   Controls whether the authentication backend uses PKCE (Proof Key For Code Exchange) during the authorization code flow.
+
+   .. seealso::
+
+      https://datatracker.ietf.org/doc/html/rfc7636
+
+.. py:attribute:: OIDC_PKCE_CODE_CHALLENGE_METHOD
+
+   :default: ``S256``
+
+   Sets the method used to generate the PKCE code challenge.
+
+   Supported methods are:
+
+   * **plain**:
+      ``code_challenge = code_verifier``
+
+   * **S256**:
+      ``code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))``
+
+   .. note::
+
+      This only has an effect if ``OIDC_USE_PKCE`` is ``True``.
+
+   .. seealso::
+
+      https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+
+.. py:attribute:: OIDC_PKCE_CODE_VERIFIER_SIZE
+
+   :default: ``64``
+
+   Sets the length of the random string used for the PKCE code verifier.  Must be between ``43`` and ``128`` inclusive.
+
+   .. note::
+
+      This only has an effect if ``OIDC_USE_PKCE`` is ``True``.
+
+   .. seealso::
+
+      https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
+

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -14,7 +14,7 @@ from django.utils.module_loading import import_string
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.utils import (
     absolutify,
-    add_state_and_nonce_to_session,
+    add_state_and_verifier_and_nonce_to_session,
     import_from_settings,
 )
 
@@ -152,7 +152,7 @@ class SessionRefresh(MiddlewareMixin):
             nonce = get_random_string(self.OIDC_NONCE_SIZE)
             params.update({"nonce": nonce})
 
-        add_state_and_nonce_to_session(request, state, params)
+        add_state_and_verifier_and_nonce_to_session(request, state, params)
 
         request.session["oidc_login_next"] = request.get_full_path()
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -1,12 +1,13 @@
 import logging
 import time
 import warnings
-
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-
+from hashlib import sha256
 from urllib.request import parse_http_list, parse_keqv_list
 
+# Make it obvious that these aren't the usual base64 functions
+import josepy.b64
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,15 +55,74 @@ def is_authenticated(user):
     return user.is_authenticated
 
 
-def add_state_and_nonce_to_session(request, state, params):
+def base64_url_encode(bytes_like_obj):
+    """Return a URL-Safe, base64 encoded version of bytes_like_obj
+
+    Implements base64urlencode as described in
+    https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
     """
-    Stores the `state` and `nonce` parameters in a session dictionary including the time when it
-    was added. The dictionary can contain multiple state/nonce combinations to allow parallel
-    logins with multiple browser sessions.
-    To keep the session space to a reasonable size, the dictionary is kept at 50 state/nonce
-    combinations maximum.
+
+    s = josepy.b64.b64encode(bytes_like_obj).decode("ascii")  # base64 encode
+    # the josepy base64 encoder (strips '='s padding) automatically
+    s = s.replace("+", "-")  # 62nd char of encoding
+    s = s.replace("/", "_")  # 63rd char of encoding
+
+    return s
+
+
+def base64_url_decode(string_like_obj):
+    """Return the bytes encoded in a URL-Safe, base64 encoded string
+    Implements inverse of base64urlencode as described in
+    https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
+    This function is not used by the OpenID client; it's just for testing PKCE related functions.
+    """
+    s = string_like_obj
+
+    s = s.replace("_", "/")  # 63rd char of encoding
+    s = s.replace("-", "+")  # 62nd char of encoding
+    b = josepy.b64.b64decode(s)  # josepy base64 encoder (decodes without '='s padding)
+
+    return b
+
+
+def generate_code_challenge(code_verifier, method):
+    """Return a code_challege, which proves knowledge of the code_verifier.
+    The code challenge is generated according to method which must be one
+    of the methods defined in https://datatracker.ietf.org/doc/html/rfc7636#section-4.2:
+    - plain:
+      code_challenge = code_verifier
+    - S256:
+      code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+    """
+
+    if method == "plain":
+        return code_verifier
+
+    elif method == "S256":
+        return base64_url_encode(sha256(code_verifier.encode("ascii")).digest())
+
+    else:
+        raise ValueError("code challenge method must be 'plain' or 'S256'.")
+
+
+def add_state_and_verifier_and_nonce_to_session(
+    request, state, params, code_verifier=None
+):
+    """
+    Stores the `state` and `nonce` parameters and an optional `code_verifier` (for PKCE) in a
+    session dictionary which maps `state` -> {nonce, code_verifier}.  Each entry includes
+    the time when it was added. The dictionary can contain multiple state -> {nonce, code_verifier}
+    mappings to allow parallel logins with multiple browser sessions.
+    To keep the session space to a reasonable size, the dictionary is kept at 50
+    state -> {nonce, code_verifier} mappings maximum.
     """
     nonce = params.get("nonce")
+
+    # OPs supporting PKCE will require `code_verifier` to be sent to the token
+    # endpoint if `code_challenge` is sent to the authentication endpoint.
+    # Make sure that `code_challenge` and `code_verifier` are both specified
+    # or neither is.
+    assert ("code_challenge" in params) == (code_verifier is not None)
 
     # Store Nonce with the State parameter in the session "oidc_states" dictionary.
     # The dictionary can store multiple State/Nonce combinations to allow parallel
@@ -95,6 +155,7 @@ def add_state_and_nonce_to_session(request, state, params):
             del request.session["oidc_states"][oldest_state]
 
     request.session["oidc_states"][state] = {
+        "code_verifier": code_verifier,
         "nonce": nonce,
         "added_on": time.time(),
     }

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -1,4 +1,5 @@
 import time
+from urllib.parse import urlencode
 
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation
@@ -6,15 +7,7 @@ from django.http import HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.crypto import get_random_string
-
-try:
-    from django.utils.http import url_has_allowed_host_and_scheme
-except ImportError:
-    # Django <= 2.2
-    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
-
-from urllib.parse import urlencode
-
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.module_loading import import_string
 from django.views.generic import View
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -1,5 +1,4 @@
 import time
-from urllib.parse import urlencode
 
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation
@@ -7,13 +6,22 @@ from django.http import HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.crypto import get_random_string
-from django.utils.http import url_has_allowed_host_and_scheme
+
+try:
+    from django.utils.http import url_has_allowed_host_and_scheme
+except ImportError:
+    # Django <= 2.2
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+
+from urllib.parse import urlencode
+
 from django.utils.module_loading import import_string
 from django.views.generic import View
 
 from mozilla_django_oidc.utils import (
     absolutify,
-    add_state_and_nonce_to_session,
+    add_state_and_verifier_and_nonce_to_session,
+    generate_code_challenge,
     import_from_settings,
 )
 
@@ -92,15 +100,18 @@ class OIDCAuthenticationCallbackView(View):
             if "oidc_states" not in request.session:
                 return self.login_failure()
 
-            # State and Nonce are stored in the session "oidc_states" dictionary.
-            # State is the key, the value is a dictionary with the Nonce in the "nonce" field.
+            # State, Nonce and PKCE Code Verifier are stored in the session "oidc_states"
+            # dictionary.
+            # State is the key, the value is a dictionary with the Nonce in the "nonce" field, and
+            # Code Verifier or None in the "code_verifier" field.
             state = request.GET.get("state")
             if state not in request.session["oidc_states"]:
                 msg = "OIDC callback state not found in session `oidc_states`!"
                 raise SuspiciousOperation(msg)
 
-            # Get the nonce from the dictionary for further processing and delete the entry to
-            # prevent replay attacks.
+            # Get the nonce and optional code verifier from the dictionary for further processing
+            # and delete the entry to prevent replay attacks.
+            code_verifier = request.session["oidc_states"][state].get("code_verifier")
             nonce = request.session["oidc_states"][state]["nonce"]
             del request.session["oidc_states"][state]
 
@@ -115,6 +126,7 @@ class OIDCAuthenticationCallbackView(View):
             kwargs = {
                 "request": request,
                 "nonce": nonce,
+                "code_verifier": code_verifier,
             }
 
             self.user = auth.authenticate(**kwargs)
@@ -192,7 +204,36 @@ class OIDCAuthenticationRequestView(View):
             nonce = get_random_string(self.get_settings("OIDC_NONCE_SIZE", 32))
             params.update({"nonce": nonce})
 
-        add_state_and_nonce_to_session(request, state, params)
+        if self.get_settings("OIDC_USE_PKCE", True):
+            code_verifier_length = self.get_settings("OIDC_PKCE_CODE_VERIFIER_SIZE", 64)
+            # Check that code_verifier_length is between the min and max length
+            # defined in https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
+            if not (43 <= code_verifier_length <= 128):
+                raise ValueError("code_verifier_length must be between 43 and 128")
+
+            # Generate code_verifier and code_challenge pair
+            code_verifier = get_random_string(code_verifier_length)
+            code_challenge_method = self.get_settings(
+                "OIDC_PKCE_CODE_CHALLENGE_METHOD", "S256"
+            )
+            code_challenge = generate_code_challenge(
+                code_verifier, code_challenge_method
+            )
+
+            # Append code_challenge to authentication request parameters
+            params.update(
+                {
+                    "code_challenge": code_challenge,
+                    "code_challenge_method": code_challenge_method,
+                }
+            )
+
+        else:
+            code_verifier = None
+
+        add_state_and_verifier_and_nonce_to_session(
+            request, state, params, code_verifier
+        )
 
         request.session["oidc_login_next"] = get_next_url(request, redirect_field_name)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,10 @@ from mock import MagicMock
 
 from mozilla_django_oidc.utils import (
     absolutify,
-    add_state_and_nonce_to_session,
+    add_state_and_verifier_and_nonce_to_session,
+    base64_url_decode,
+    base64_url_encode,
+    generate_code_challenge,
     import_from_settings,
 )
 
@@ -49,6 +52,85 @@ class AbsolutifyTestCase(TestCase):
         self.assertEqual(url, "https://testserver/evil.com/foo/bar")
 
 
+class Base64URLEncodeTestCase(TestCase):
+    def test_base64_url_encode(self):
+        """
+        Tests creating a url-safe base64 encoded string from bytes.
+        Source: https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
+        """
+        data = bytes((3, 236, 255, 224, 193))
+        encoded = base64_url_encode(data)
+
+        # Using base64.b64encode() returns b'A+z/4ME='.
+        # Our implementation should strip tailing '='s padding.
+        # and replace '+' with '-' and '/' with '_'.
+        self.assertEqual(encoded, "A-z_4ME")
+
+        # Decoding should return the original data.
+        decoded = base64_url_decode(encoded)
+        self.assertEqual(decoded, data)
+
+    def test_base64_url_encode_empty_input(self):
+        """
+        Tests creating a url-safe base64 encoded string from an empty bytes instance.
+        """
+        data = bytes()
+        encoded = base64_url_encode(data)
+        self.assertEqual(encoded, "")
+
+        decoded = base64_url_decode(encoded)
+        self.assertEqual(decoded, data)
+
+    def test_base64_url_encode_double_padding(self):
+        """
+        Test encoding a string whoose base64.b64encode encoding ends with '=='.
+        """
+        data = bytes((3, 236, 255, 224, 193, 222, 22))
+        encoded = base64_url_encode(data)
+
+        # Using base64.b64encode() returns b'A+z/4MHeFg=='.
+        self.assertEqual(encoded, "A-z_4MHeFg")
+
+        # Decoding should return the original data.
+        decoded = base64_url_decode(encoded)
+        self.assertEqual(decoded, data)
+
+
+class PKCECodeVerificationTestCase(TestCase):
+    def test_generate_code_challenge(self):
+        """
+        Tests that a code challenge is generated correctly with the 'S256' method.
+        """
+        code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        code_challenge = generate_code_challenge(code_verifier, "S256")
+
+        self.assertEqual(code_challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+
+    def test_generate_plain_code_challenge(self):
+        """
+        Tests that a code challenge is generated correctly with the 'plain' method.
+        """
+        code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        code_challenge = generate_code_challenge(code_verifier, "plain")
+
+        self.assertEqual(code_challenge, code_verifier)
+
+    def test_generate_code_challenge_invalid_method(self):
+        """
+        Tests that an exception is raised when an invalid code challenge method is provided.
+        """
+        code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+        try:
+            generate_code_challenge(code_verifier, "INVALID")
+            self.fail(
+                "generate_code_challenge() should raise an exception when an invalid"
+                " code challenge method is provided."
+            )
+        except ValueError:
+            pass
+
+
 class SessionStateTestCase(TestCase):
     def setUp(self):
         self.request = RequestFactory().get("/doesnt/matter")
@@ -62,7 +144,7 @@ class SessionStateTestCase(TestCase):
         state = "example_state"
         params = {}
 
-        add_state_and_nonce_to_session(self.request, state, params)
+        add_state_and_verifier_and_nonce_to_session(self.request, state, params)
 
         self.assertIn("oidc_states", self.request.session)
         self.assertEqual(1, len(self.request.session["oidc_states"]))
@@ -73,12 +155,12 @@ class SessionStateTestCase(TestCase):
         state2 = "example_state_2"
         params = {}
 
-        add_state_and_nonce_to_session(self.request, state1, params)
+        add_state_and_verifier_and_nonce_to_session(self.request, state1, params)
 
         self.assertEqual(1, len(self.request.session["oidc_states"]))
         self.assertIn(state1, self.request.session["oidc_states"].keys())
 
-        add_state_and_nonce_to_session(self.request, state2, params)
+        add_state_and_verifier_and_nonce_to_session(self.request, state2, params)
 
         self.assertEqual(2, len(self.request.session["oidc_states"]))
         self.assertIn(state1, self.request.session["oidc_states"].keys())
@@ -91,14 +173,16 @@ class SessionStateTestCase(TestCase):
         params = {}
         for i in range(limit):
             state = "example_state_{}".format(i)
-            add_state_and_nonce_to_session(self.request, state, params)
+            add_state_and_verifier_and_nonce_to_session(self.request, state, params)
 
         self.assertEqual(limit, len(self.request.session["oidc_states"]))
         self.assertIn(first_state, self.request.session["oidc_states"])
 
         # Add another state which should remove the very first one
         additional_state = "example_state"
-        add_state_and_nonce_to_session(self.request, additional_state, params)
+        add_state_and_verifier_and_nonce_to_session(
+            self.request, additional_state, params
+        )
 
         # Make sure the oldest state was deleted
         self.assertNotIn(first_state, self.request.session["oidc_states"])
@@ -112,7 +196,7 @@ class SessionStateTestCase(TestCase):
         state = "example_state"
         params = {}
 
-        add_state_and_nonce_to_session(self.request, state, params)
+        add_state_and_verifier_and_nonce_to_session(self.request, state, params)
 
         # Test state dictionary
         self.assertIn(state, self.request.session["oidc_states"].keys())
@@ -130,6 +214,6 @@ class SessionStateTestCase(TestCase):
         state = "example_state"
         params = {"nonce": "example_nonce"}
 
-        add_state_and_nonce_to_session(self.request, state, params)
+        add_state_and_verifier_and_nonce_to_session(self.request, state, params)
 
         self.assertNotEqual(self.request.session["oidc_states"][state]["nonce"], None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,14 +121,8 @@ class PKCECodeVerificationTestCase(TestCase):
         """
         code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 
-        try:
-            generate_code_challenge(code_verifier, "INVALID")
-            self.fail(
-                "generate_code_challenge() should raise an exception when an invalid"
-                " code challenge method is provided."
-            )
-        except ValueError:
-            pass
+        self.assertRaises(ValueError, generate_code_challenge, code_verifier, "INVALID")
+
 
 
 class SessionStateTestCase(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,16 +1,16 @@
 import time
-
 from urllib.parse import parse_qs, urlparse
 
-from mock import patch
-
-from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import SuspiciousOperation
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
-from django.test import RequestFactory, TestCase, override_settings, Client
+from mock import patch
 
 from mozilla_django_oidc import views
+
+TEST_CODE_VERIFIER = "ThisStringIsURLSafeAndAtLeast43Characters00"
 
 
 User = get_user_model()
@@ -35,7 +35,11 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         client = Client()
         request.session = client.session
         request.session["oidc_states"] = {
-            "example_state": {"nonce": None, "added_on": time.time()},
+            "example_state": {
+                "code_verifier": TEST_CODE_VERIFIER,
+                "nonce": None,
+                "added_on": time.time(),
+            },
         }
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
 
@@ -44,7 +48,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
                 mock_auth.return_value = user
                 response = callback_view(request)
 
-                mock_auth.assert_called_once_with(nonce=None, request=request)
+                mock_auth.assert_called_once_with(
+                    code_verifier=TEST_CODE_VERIFIER, nonce=None, request=request
+                )
                 mock_login.assert_called_once_with(request, user)
 
         self.assertEqual(response.status_code, 302)
@@ -61,7 +67,11 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
         client = Client()
         request.session = client.session
         request.session["oidc_states"] = {
-            "example_state": {"nonce": None, "added_on": time.time()},
+            "example_state": {
+                "code_verifier": TEST_CODE_VERIFIER,
+                "nonce": None,
+                "added_on": time.time(),
+            },
         }
         request.session["oidc_login_next"] = "/foobar"
         callback_view = views.OIDCAuthenticationCallbackView.as_view()
@@ -71,11 +81,46 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
                 mock_auth.return_value = user
                 response = callback_view(request)
 
-                mock_auth.assert_called_once_with(nonce=None, request=request)
+                mock_auth.assert_called_once_with(
+                    code_verifier=TEST_CODE_VERIFIER, nonce=None, request=request
+                )
                 mock_login.assert_called_once_with(request, user)
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/foobar")
+
+    @override_settings(LOGIN_REDIRECT_URL="/success")
+    def test_get_auth_success_without_pkce(self):
+        """Test successful callback request to RP after disabling PKCE."""
+        user = User.objects.create_user("example_username")
+
+        get_data = {"code": "example_code", "state": "example_state"}
+        url = reverse("oidc_authentication_callback")
+        request = self.factory.get(url, get_data)
+        client = Client()
+        request.session = client.session
+        request.session["oidc_states"] = {
+            "example_state": {
+                # Simulates an auth request sent with PKCE disabled
+                # 'code_verifier': TEST_CODE_VERIFIER,
+                "nonce": None,
+                "added_on": time.time(),
+            },
+        }
+        callback_view = views.OIDCAuthenticationCallbackView.as_view()
+
+        with patch("mozilla_django_oidc.views.auth.authenticate") as mock_auth:
+            with patch("mozilla_django_oidc.views.auth.login") as mock_login:
+                mock_auth.return_value = user
+                response = callback_view(request)
+
+                mock_auth.assert_called_once_with(
+                    code_verifier=None, nonce=None, request=request
+                )
+                mock_login.assert_called_once_with(request, user)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/success")
 
     @override_settings(LOGIN_REDIRECT_URL_FAILURE="/failure")
     def test_get_auth_failure_nonexisting_user(self):
@@ -95,7 +140,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
             mock_auth.return_value = None
             response = callback_view(request)
 
-            mock_auth.assert_called_once_with(nonce=None, request=request)
+            mock_auth.assert_called_once_with(
+                code_verifier=None, nonce=None, request=request
+            )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/failure")
@@ -122,7 +169,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
             mock_auth.return_value = user
             response = callback_view(request)
 
-            mock_auth.assert_called_once_with(request=request, nonce=None)
+            mock_auth.assert_called_once_with(
+                code_verifier=None, request=request, nonce=None
+            )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/failure")
@@ -239,7 +288,7 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
                 response = callback_view(request)
 
                 mock_auth.assert_called_once_with(
-                    nonce="example_nonce", request=request
+                    code_verifier=None, nonce="example_nonce", request=request
                 )
                 mock_login.assert_called_once_with(request, user)
 
@@ -289,7 +338,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
             with patch("mozilla_django_oidc.views.auth.login") as mock_login:
                 mock_auth.return_value = user
                 response = callback_view(request)
-                mock_auth.assert_called_once_with(nonce=None, request=request)
+                mock_auth.assert_called_once_with(
+                    code_verifier=None, nonce=None, request=request
+                )
                 mock_login.assert_called_once_with(request, user)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/success")
@@ -304,7 +355,9 @@ class OIDCAuthorizationCallbackViewTestCase(TestCase):
             with patch("mozilla_django_oidc.views.auth.login") as mock_login:
                 mock_auth.return_value = user
                 response = callback_view(request)
-                mock_auth.assert_called_once_with(nonce=None, request=request)
+                mock_auth.assert_called_once_with(
+                    code_verifier=None, nonce=None, request=request
+                )
                 mock_login.assert_not_called()
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/success")
@@ -436,6 +489,48 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
         o = urlparse(response.url)
+        query_dict = parse_qs(o.query)
+
+        # The PKCE code_challenge should be a random string between 43 and 128 characters.
+        # Since it's random, we can only test that it's present and has the right length.
+        # Then we just insert it into the expected_query.
+        self.assertIn("code_challenge", query_dict)
+        self.assertTrue(
+            len(query_dict["code_challenge"]) == 1
+            and 43 <= len(query_dict["code_challenge"][0]) <= 128
+        )
+        expected_query = {
+            "code_challenge": query_dict["code_challenge"],
+            "code_challenge_method": ["S256"],
+            "response_type": ["code"],
+            "scope": ["openid email"],
+            "client_id": ["example_id"],
+            "redirect_uri": ["http://testserver/callback/"],
+            "state": ["examplestring"],
+            "nonce": ["examplestring"],
+        }
+        self.assertDictEqual(query_dict, expected_query)
+        self.assertEqual(o.hostname, "server.example.com")
+        self.assertEqual(o.path, "/auth")
+
+    @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
+    @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=False)
+    @patch("mozilla_django_oidc.views.get_random_string")
+    def test_get_without_PKCE(self, mock_views_random):
+        """Test initiation of a successful OIDC attempt with PKCE disabled."""
+        mock_views_random.return_value = "examplestring"
+        url = reverse("oidc_authentication_init")
+        request = self.factory.get(url)
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+        response = login_view(request)
+        self.assertEqual(response.status_code, 302)
+
+        o = urlparse(response.url)
+        query_dict = parse_qs(o.query)
+
+        # PKCE is disabled, so code_challenge and code_challenge_method should not be present.
         expected_query = {
             "response_type": ["code"],
             "scope": ["openid email"],
@@ -444,9 +539,51 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             "state": ["examplestring"],
             "nonce": ["examplestring"],
         }
-        self.assertDictEqual(parse_qs(o.query), expected_query)
+        self.assertDictEqual(query_dict, expected_query)
         self.assertEqual(o.hostname, "server.example.com")
         self.assertEqual(o.path, "/auth")
+
+    @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
+    @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
+    @override_settings(OIDC_PKCE_CODE_VERIFIER_SIZE=42)  # must be between 43 and 128
+    @patch("mozilla_django_oidc.views.get_random_string")
+    def test_get_invalid_code_verifier_size_too_short(self, mock_views_random):
+        """Test initiation of an OIDC attempt with an invalid code verifier size."""
+        mock_views_random.return_value = "examplestring"
+        url = reverse("oidc_authentication_init")
+        request = self.factory.get(url)
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+        try:
+            login_view(request)
+            self.fail(
+                "OIDC_PKCE_CODE_VERIFIER_SIZE must be between 43 and 128,"
+                " but OIDC_PKCE_CODE_VERIFIER_SIZE was 42 and no exception was raised."
+            )
+        except ValueError:
+            pass
+
+    @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
+    @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
+    @override_settings(OIDC_PKCE_CODE_VERIFIER_SIZE=129)  # must be between 43 and 128
+    @patch("mozilla_django_oidc.views.get_random_string")
+    def test_get_invalid_code_verifier_size_too_long(self, mock_views_random):
+        """Test initiation of an OIDC attempt with an invalid code verifier size."""
+        mock_views_random.return_value = "examplestring"
+        url = reverse("oidc_authentication_init")
+        request = self.factory.get(url)
+        request.session = dict()
+        login_view = views.OIDCAuthenticationRequestView.as_view()
+        try:
+            login_view(request)
+            self.fail(
+                "OIDC_PKCE_CODE_VERIFIER_SIZE must be between 43 and 128,"
+                " but OIDC_PKCE_CODE_VERIFIER_SIZE was 129 and no exception was raised."
+            )
+        except ValueError:
+            pass
 
     @override_settings(ROOT_URLCONF="tests.namespaced_urls")
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
@@ -466,7 +603,19 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
         o = urlparse(response.url)
+        query_dict = parse_qs(o.query)
+
+        # The PKCE code_challenge should be a random string between 43 and 128 characters.
+        # Since it's random, we can only test that it's present and has the right length.
+        # Then we just insert it into the expected_query.
+        self.assertIn("code_challenge", query_dict)
+        self.assertTrue(
+            len(query_dict["code_challenge"]) == 1
+            and 43 <= len(query_dict["code_challenge"][0]) <= 128
+        )
         expected_query = {
+            "code_challenge": query_dict["code_challenge"],
+            "code_challenge_method": ["S256"],
             "response_type": ["code"],
             "scope": ["openid email"],
             "client_id": ["example_id"],
@@ -474,7 +623,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             "state": ["examplestring"],
             "nonce": ["examplestring"],
         }
-        self.assertDictEqual(parse_qs(o.query), expected_query)
+        self.assertDictEqual(query_dict, expected_query)
         self.assertEqual(o.hostname, "server.example.com")
         self.assertEqual(o.path, "/auth")
 
@@ -495,7 +644,19 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
         o = urlparse(response.url)
+        query_dict = parse_qs(o.query)
+
+        # The PKCE code_challenge should be a random string between 43 and 128 characters.
+        # Since it's random, we can only test that it's present and has the right length.
+        # Then we just insert it into the expected_query.
+        self.assertIn("code_challenge", query_dict)
+        self.assertTrue(
+            len(query_dict["code_challenge"]) == 1
+            and 43 <= len(query_dict["code_challenge"][0]) <= 128
+        )
         expected_query = {
+            "code_challenge": query_dict["code_challenge"],
+            "code_challenge_method": ["S256"],
             "response_type": ["code"],
             "scope": ["openid email"],
             "client_id": ["example_id"],
@@ -504,7 +665,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
             "nonce": ["examplestring"],
             "audience": ["some-api.example.com"],
         }
-        self.assertDictEqual(parse_qs(o.query), expected_query)
+        self.assertDictEqual(query_dict, expected_query)
         self.assertEqual(o.hostname, "server.example.com")
         self.assertEqual(o.path, "/auth")
 
@@ -528,7 +689,19 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
         o = urlparse(response.url)
+        query_dict = parse_qs(o.query)
+
+        # The PKCE code_challenge should be a random string between 43 and 128 characters.
+        # Since it's random, we can only test that it's present and has the right length.
+        # Then we just insert it into the expected_query.
+        self.assertIn("code_challenge", query_dict)
+        self.assertTrue(
+            len(query_dict["code_challenge"]) == 1
+            and 43 <= len(query_dict["code_challenge"][0]) <= 128
+        )
         expected_query = {
+            "code_challenge": query_dict["code_challenge"],
+            "code_challenge_method": ["S256"],
             "response_type": ["code"],
             "scope": ["openid email"],
             "client_id": ["example_id"],


### PR DESCRIPTION
Adjust comments

Remove .devcontainer

Default challenge method to S256

Fix base64 encoding

PKCE Unit Tests

Fix code_verifier KeyError

Test code_verifier parameter

AuthoricationRequestView test code_verifier

Replace assert_ with assertTrue

Replace all assert_ calls with assertTrue

Fix flake8 errors

Fix flake8 warnings

Test PKCE settings

Check for AssertionError rather than ValueError

Update documentation

Change AssertionError to ValueError