### PR TITLE
disable PKCE by default

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -281,7 +281,7 @@ of ``mozilla-django-oidc``.
 
 .. py:attribute:: OIDC_USE_PKCE
 
-   :default: ``True``
+   :default: ``False``
 
    Controls whether the authentication backend uses PKCE (Proof Key For Code Exchange) during the authorization code flow.
 
@@ -324,4 +324,3 @@ of ``mozilla-django-oidc``.
    .. seealso::
 
       https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
-

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -88,7 +88,6 @@ class OIDCAuthenticationCallbackView(View):
                 auth.logout(request)
             assert not request.user.is_authenticated
         elif "code" in request.GET and "state" in request.GET:
-
             # Check instead of "oidc_state" check if the "oidc_states" session key exists!
             if "oidc_states" not in request.session:
                 return self.login_failure()
@@ -197,7 +196,7 @@ class OIDCAuthenticationRequestView(View):
             nonce = get_random_string(self.get_settings("OIDC_NONCE_SIZE", 32))
             params.update({"nonce": nonce})
 
-        if self.get_settings("OIDC_USE_PKCE", True):
+        if self.get_settings("OIDC_USE_PKCE", False):
             code_verifier_length = self.get_settings("OIDC_PKCE_CODE_VERIFIER_SIZE", 64)
             # Check that code_verifier_length is between the min and max length
             # defined in https://datatracker.ietf.org/doc/html/rfc7636#section-4.1

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -477,6 +477,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
     @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
     @patch("mozilla_django_oidc.views.get_random_string")
     def test_get(self, mock_views_random):
         """Test initiation of a successful OIDC attempt."""
@@ -588,6 +589,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
     @override_settings(ROOT_URLCONF="tests.namespaced_urls")
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
     @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
     @override_settings(
         OIDC_AUTHENTICATION_CALLBACK_URL="namespace:oidc_authentication_callback"
     )
@@ -629,6 +631,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
     @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
     @override_settings(
         OIDC_AUTH_REQUEST_EXTRA_PARAMS={"audience": "some-api.example.com"}
     )
@@ -671,6 +674,7 @@ class OIDCAuthorizationRequestViewTestCase(TestCase):
 
     @override_settings(OIDC_OP_AUTHORIZATION_ENDPOINT="https://server.example.com/auth")
     @override_settings(OIDC_RP_CLIENT_ID="example_id")
+    @override_settings(OIDC_USE_PKCE=True)
     @patch("mozilla_django_oidc.views.get_random_string")
     @patch("mozilla_django_oidc.views.OIDCAuthenticationRequestView.get_extra_params")
     def test_get_with_overridden_extra_params(


### PR DESCRIPTION
Not all authorization providers yet support PKCE layered on top of the normal, secret-based authorization code flow -- for example, [Mozilla Accounts explicitly forbids it](https://github.com/mozilla/fxa-auth-server/blob/master/fxa-oauth-server/docs/api.md#request-parameters-7) -- so in order to avoid the next release being a potentially breaking change, let's set the default value of `OIDC_USE_PKCE` to `False`.