### PR TITLE
Support application/jwt in userinfo endpoint

### DIFF
--- a/mozilla_django_oidc/_jose.py
+++ b/mozilla_django_oidc/_jose.py
@@ -1,0 +1,79 @@
+"""
+Helpers for dealing with Javascript Object Signing and Encryption (JOSE) in an OpenID
+Connect context.
+"""
+import json
+from typing import Dict, Any, TypeAlias, Union
+
+from django.core.exceptions import SuspiciousOperation
+from django.utils.encoding import smart_bytes
+
+from josepy.jwk import JWK
+from josepy.jws import JWS
+
+# values could be narrowed down to relevant JSON types.
+Payload: TypeAlias = Dict[str, Any]
+
+
+def verify_jws_and_decode(
+    token: bytes,
+    key,
+    signing_algorithm: str = "",
+    decode_json: bool = False,  # for backwards compatibility reasons
+) -> Union[Payload, bytes]:
+    """
+    Cryptographically verify the passed in token and return the decoded payload.
+
+    Verification is done with utilities from the josepy library.
+
+    :arg token: the raw binary content of the JWT/token.
+    :arg key: the key to verify the signature with. This may be a key obtained from
+      the OIDC_OP_JWKS_ENDPOINT or a shared key as a string (XXX CONFIRM THIS!)
+    :arg signing_algorithm: If provided, the token must employ this exact signing
+      algorithm. Values must be valid names from algorithms in :mod:`josepy.jwa`.
+    :arg decode_json: If true, the payload will be json-decoded and return a Python
+      object rather than a bytestring.
+    :return: the extracted payload object, deserialized from JSON.
+    :raises SuspiciousOperation: if the token verification fails.
+    """
+    jws = JWS.from_compact(token)
+
+    # validate the signing algorithm
+    if (alg := jws.signature.combined.alg) is None:
+        msg = "No alg value found in header"
+        raise SuspiciousOperation(msg)
+
+    if signing_algorithm and signing_algorithm != alg.name:
+        msg = (
+            "The provider algorithm {!r} does not match the client's "
+            "expected signing algorithm.".format(alg)
+        )
+        raise SuspiciousOperation(msg)
+
+    # one of the most common implementation weaknesses -> attacker can supply 'none'
+    # algorithm
+    # XXX: check if this is okay, technically users can now set
+    # settings.OIDC_RP_SIGN_ALGO = "none" and things should work?
+    if alg.name == "none":
+        raise SuspiciousOperation("'none' for alg value is not allowed")
+
+    # process the key parameter which was/may have been loaded from keys endpoint
+    if isinstance(key, str):
+        # Use smart_bytes here since the key string comes from settings.
+        jwk = JWK.load(smart_bytes(key))
+    else:
+        # The key is a json returned from the IDP JWKS endpoint.
+        jwk = JWK.from_json(key)
+        # address some missing upstream Self type declarations
+        assert isinstance(jwk, JWK)
+
+    if not jws.verify(jwk):
+        msg = "JWS token verification failed."
+        raise SuspiciousOperation(msg)
+
+    # return the decoded JSON or the raw bytestring payload
+    payload = jws.payload
+    if not decode_json:
+        return payload
+    else:
+        return json.loads(payload.decode("utf-8"))

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -8,6 +8,7 @@ from urllib.request import parse_http_list, parse_keqv_list
 import josepy.b64
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from requests.utils import _parse_content_type_header  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +20,19 @@ def parse_www_authenticate_header(header):
     """
     items = parse_http_list(header)
     return parse_keqv_list(items)
+
+
+def extract_content_type(ct_header: str) -> str:
+    """
+    Get the content type + parameters from content type header.
+
+    This is internal API since we use a requests internal utility, which may be
+    removed/modified at any time. However, this is a deliberate choices since I trust
+    requests to have a correct implementation more than coming up with one myself.
+    """
+    content_type, _ = _parse_content_type_header(ct_header)
+    # discard the params, we only want the content type itself
+    return content_type
 
 
 def import_from_settings(attr, *args):


### PR DESCRIPTION
Closes #517

This is an initial draft to spark discussion about implementation details.

Changes:

* Refactored the JWS verification into a generic helper - the goal is that the middleware methods are backwards compatible
* Added (partial) handling for `application/jwt` processing in the userinfo endpoint

Topics to discuss:

* test failures due to missing Content-Type header -> can we use a utility like vcr.py to record real requests instead of using unittest.mock / request mocking approaches? My experience is that those tools are very fragile
* I have a keycloak setup that can be added to the docker-compose which is configured for application/jwt - this is a powerful test setup with vcr.py from the above bullet
* How do we handle keys that are not loaded from a JWKS endpoint? I think a new setting would be relevant, but is that even a case you want to support and/or is used in real deployments? Looking at the code again, I'm not sure that HMAC 256 is even configurable?
* I've used type annotations because they help me write better code - some maintainers have strong opinions about these, just let me know your position about this and I'll adapt.
* Is this the right direction? It works like a breeze for us in our downstream library, but I'm open to feedback of course
* How do you feel about block-listing algorithm `none`?
* I looked into re-using `parse_www_authenticate_header` for the content type header processing, but it kinda borks on a value like `application/json; charset=utf-8`, so instead I use the (private) utility from the `requests` library which can be controversial. I don't trust myself enough to correctly and safely parse HTTP headers :grimacing: 