### PR TITLE
Ability to parse JWT UserInfo payload

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -279,6 +279,12 @@ class OIDCAuthenticationBackend(ModelBackend):
             proxies=self.get_settings("OIDC_PROXY", None),
         )
         user_response.raise_for_status()
+
+        if user_response.headers.get("content-type", "").startswith("application/jwt"):
+            # OIDC userinfo claims can be encoded as JWT
+            return self.verify_token(user_response.text)
+
+        # otherwise process as JSON payload
         return user_response.json()
 
     def authenticate(self, request, **kwargs):


### PR DESCRIPTION
A possible fix for #548 + simple content-type test