### PR TITLE
Resolve the redirect URL to be consistent with how Django handles it

### DIFF
--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -251,7 +251,7 @@ class OIDCLogoutView(View):
     @property
     def redirect_url(self):
         """Return the logout url defined in settings."""
-        return self.get_settings("LOGOUT_REDIRECT_URL", "/")
+        return resolve_url(self.get_settings("LOGOUT_REDIRECT_URL", "/"))
 
     def post(self, request):
         """Log out the user."""


### PR DESCRIPTION
The views in django.contrib.auth treat the settings variables LOGIN_REDIRECT_URL and LOGOUT_REDIRECT_URL as [URL or named URL pattern](https://docs.djangoproject.com/en/dev/ref/settings/#logout-redirect-url). mozilla-django-oidc attempts to resolve LOGIN_REDIRECT_URL as a named URL pattern, but it does not resolve LOGOUT_REDIRECT_URL.

To make the behavior consistent with Django, this PR adds support for using a named URL pattern in LOGOUT_REDIRECT_URL as well.