### PR TITLE
Fix SECP256R1 instance in test_auth

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1219,7 +1219,7 @@ class OIDCAuthenticationBackendES256WithJwksEndpointTestCase(TestCase):
         self.backend = OIDCAuthenticationBackend()
 
         # Generate a private key to create a test token with
-        private_key = ec.generate_private_key(ec.SECP256R1, default_backend())
+        private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
 
         # Make the public key available through the JWKS response
         public_numbers = private_key.public_key().public_numbers()


### PR DESCRIPTION
This warning:

```
test_auth.py:1222: CryptographyDeprecationWarning: Curve argument must be an instance of an EllipticCurve class. Did you pass a class by mistake? This will be an exception in a future version of cryptography
private_key = ec.generate_private_key(ec.SECP256R1, default_backend())
```

recently turned into a failure, breaking CI.

This just gets the instance properly.