### PR TITLE
remove support for Python 3.9

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -43,12 +43,13 @@ jobs:
     # Run inside the specific Docker container for the Python version
     container:
       image: mozilla/oidc-testprovider:oidc_e2e_setup_py${{ matrix.python }}-latest
+      options: --user root
 
     strategy:
       fail-fast: false
       matrix:
         # Define the base dimensions
-        python: ['39', '310', '311', '312', '313']
+        python: ['310', '311', '312', '313', '314']
         algo: ['rs', 'hs']
         django_name: ['django420', 'django50', 'django51', 'django52']
 
@@ -64,19 +65,18 @@ jobs:
             django_spec: 'Django>=5.2,<5.3'
 
         exclude:
-          # Python 3.9 only supports Django 4.2 in this config
-          - python: '39'
-            django_name: 'django50'
-          - python: '39'
-            django_name: 'django51'
-          - python: '39'
-            django_name: 'django52'
-
           # Python 3.13 only supports Django 5.1+ in this config
           - python: '313'
             django_name: 'django420'
           - python: '313'
             django_name: 'django50'
+          # Python 3.14 only supports Django 5.2+ in this config
+          - python: '314'
+            django_name: 'django420'
+          - python: '314'
+            django_name: 'django50'
+          - python: '314'
+            django_name: 'django51'
 
     env:
       TEST_OIDC_ALGO: ${{ matrix.algo }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.9+. Check
+3. The pull request should work for Python 3.10+. Check
    `<https://github.com/mozilla/mozilla-django-oidc/actions>`_ and make sure
    that the tests pass for all supported Python versions.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ Backwards-incompatible changes:
 
 * Drop support for Django 3.2
 * Drop support for Python 3.8
-* Python 3.9 is only supported with Django 4.2 (Django 5.0+ requires Python 3.10+)
+* Drop support for Python 3.9
 
 
 4.0.1 (2024-03-12)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ After installation, you'll need to do some things to get your site using
 Requirements
 ------------
 
-This library supports Python 3.9+ on OSX and Linux.
+This library supports Python 3.10+ on OSX and Linux.
 
 
 Acquire a client id and client secret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { name = "John Giannelos", email = "jgiannelos@mozilla.com" }
 ]
 license = "MPL-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["mozilla-django-oidc"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -29,7 +29,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
     lint
-    py{39,310,311,312}-django420
+    py{310,311,312}-django420
     py{310,311,312}-django50
     py{310,311,312,313}-django51
     py{310,311,312,313,314}-django52
 
 [gh-actions]
 python =
-  3.9: py39
   3.10: py310
   3.11: py311
   3.12: py312, coverage, lint


### PR DESCRIPTION
- Removes support for Python 3.9
- Adds support for Python 3.14 in the integration tests
    - Depends on new release of https://github.com/mozilla/docker-test-mozilla-django-oidc