### PR TITLE
Update RTD config to fix docs pipeine

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 
@@ -14,9 +14,11 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
+# Optional but recommended, declare the Python requirements installation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: requirements/requirements_dev.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Removed `requirements/requirements_dev.txt` fail RTD builds, uses current `.[docs]` instead.

Also bumps OS version.