### PR TITLE
fix typo and remove deprecated Sphinx package

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ django.setup()
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "mozilla-djando-oidc"
+project = "mozilla-django-oidc"
 copyright = "2016, Mozilla"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ build = [
 docs = [
     "sphinx",
     "sphinx_rtd_theme",
-    "readthedocs-sphinx-search",
 ]
 dev = [
     "mozilla-django-oidc[test,docs,drf,lint,build]",


### PR DESCRIPTION
Fixes a typo and removes the deprecated (and unused) `readthedocs-sphinx-search` package from the docs install.