### PR TITLE
Fix error when LOGOUT_REDIRECT_URL is not set (Django default is None)

### DIFF
--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -251,7 +251,8 @@ class OIDCLogoutView(View):
     @property
     def redirect_url(self):
         """Return the logout url defined in settings."""
-        return resolve_url(self.get_settings("LOGOUT_REDIRECT_URL", "/"))
+        redirect_url = self.get_settings("LOGOUT_REDIRECT_URL")
+        return resolve_url(redirect_url if redirect_url else "/")
 
     def post(self, request):
         """Log out the user."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -760,6 +760,17 @@ class OIDCLogoutViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/example-logout")
 
+    @override_settings(LOGOUT_REDIRECT_URL=None)
+    def test_default_logout_redirect_url(self):
+        url = reverse("oidc_logout")
+        request = self.factory.post(url)
+        request.user = AnonymousUser()
+        logout_view = views.OIDCLogoutView.as_view()
+
+        response = logout_view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
+
     @override_settings(LOGOUT_REDIRECT_URL="/example-logout")
     def test_post(self):
         user = User.objects.create_user("example_username")


### PR DESCRIPTION
Fix error when LOGOUT_REDIRECT_URL is not set (Django default is None) 

See issue #576.